### PR TITLE
AI-002: declare core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,28 @@ description = "NFL Game Outcome Prediction — project scaffold"
 authors = [{ name = "AI Builder", email = "" }]
 readme = "README.md"
 requires-python = ">=3.11"
+dependencies = [
+    "nflreadpy>=0.3.1",
+    "pandas>=2.1",
+    "duckdb>=0.9",
+    "pyarrow>=14",
+    "scikit-learn>=1.3",
+    "xgboost>=1.7",
+    "mlflow>=2.9",
+    "shap>=0.44",
+    "requests>=2.31",
+    "meteostat>=1.6",
+    "typer>=0.9",
+]
+
+[project.optional-dependencies]
+viz = [
+    "matplotlib>=3.8",
+    "seaborn>=0.13",
+]
+
+[project.urls]
+# Populate with canonical repository and documentation links when available.
+
+[project.scripts]
+# CLI entry points will be registered in a future task.


### PR DESCRIPTION
## Summary
- declare Python 3.11 requirement and initial dependency set for ingestion, storage, modeling, and CLI tasks
- add optional visualization extra with matplotlib and seaborn
- add placeholder tables for future project URLs and CLI scripts

## Testing
- python -c "import tomllib,sys; tomllib.load(open('pyproject.toml','rb')); print('ok')"


------
https://chatgpt.com/codex/tasks/task_e_68d005070e9c832fbe5a34521d3f7650