### PR TITLE
AI-005 add DuckDB client helper

### DIFF
--- a/src/nfl_pred/storage/__init__.py
+++ b/src/nfl_pred/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage layer utilities for DuckDB and related persistence."""
+
+from .duckdb_client import DuckDBClient
+
+__all__ = ["DuckDBClient"]

--- a/src/nfl_pred/storage/duckdb_client.py
+++ b/src/nfl_pred/storage/duckdb_client.py
@@ -1,0 +1,85 @@
+"""DuckDB client helper providing a minimal, typed interface."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+import duckdb
+from pandas import DataFrame
+
+
+_TABLE_MODES = {"create", "replace", "append"}
+
+
+@dataclass(slots=True)
+class DuckDBClient(AbstractContextManager["DuckDBClient"]):
+    """Context manager wrapper around a DuckDB connection."""
+
+    db_path: str
+    read_only: bool = False
+    _connection: duckdb.DuckDBPyConnection | None = field(init=False, default=None, repr=False)
+
+    def __enter__(self) -> "DuckDBClient":
+        if self._connection is None:
+            self._connection = duckdb.connect(database=self.db_path, read_only=self.read_only)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool | None:  # pragma: no cover - exercised indirectly
+        self.close()
+        return None
+
+    @property
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        if self._connection is None:
+            raise RuntimeError("DuckDBClient connection has not been opened.")
+        return self._connection
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def execute(self, sql: str, params: Mapping[str, Any] | None = None) -> duckdb.DuckDBPyConnection:
+        """Execute a SQL statement, useful for DDL or imperative commands."""
+        return self.connection.execute(sql, params)
+
+    def read_sql(self, sql: str, params: Mapping[str, Any] | None = None) -> DataFrame:
+        """Run a SQL query and return the results as a pandas ``DataFrame``."""
+        result = self.connection.execute(sql, params)
+        return result.fetch_df()
+
+    def write_df(self, df: DataFrame, table: str, mode: str = "create") -> None:
+        """Persist a ``DataFrame`` into a DuckDB table using the requested mode."""
+        if mode not in _TABLE_MODES:
+            raise ValueError(f"Unsupported write mode '{mode}'. Expected one of {_TABLE_MODES}.")
+
+        temp_view = f"__df_{uuid4().hex}"
+        self.connection.register(temp_view, df)
+        identifier = duckdb.escape_identifier(table)
+
+        try:
+            if mode == "create":
+                self.connection.execute(f"CREATE TABLE {identifier} AS SELECT * FROM {temp_view}")
+            elif mode == "replace":
+                self.connection.execute(f"CREATE OR REPLACE TABLE {identifier} AS SELECT * FROM {temp_view}")
+            else:  # append
+                if not self.connection.table_exists(table):
+                    raise RuntimeError(f"Table '{table}' does not exist for append mode.")
+                self.connection.execute(f"INSERT INTO {identifier} SELECT * FROM {temp_view}")
+        finally:
+            self.connection.unregister(temp_view)
+
+    def register_parquet(self, path: str, view: str) -> None:
+        """Create or replace a view selecting from a Parquet file."""
+        identifier = duckdb.escape_identifier(view)
+        self.connection.execute(
+            f"CREATE OR REPLACE VIEW {identifier} AS SELECT * FROM read_parquet(:path)",
+            {"path": path},
+        )
+
+
+__all__ = ["DuckDBClient"]


### PR DESCRIPTION
## Summary
- add a typed DuckDBClient context manager for opening connections and executing SQL
- support DataFrame persistence with create, replace, and append modes and registering Parquet views
- expose storage utilities via the storage package init

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d00bda2658832f9ed292925aeb3c51