### PR TITLE
AI-006: add DuckDB schema definitions

### DIFF
--- a/src/nfl_pred/storage/duckdb_client.py
+++ b/src/nfl_pred/storage/duckdb_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
@@ -46,6 +47,13 @@ class DuckDBClient(AbstractContextManager["DuckDBClient"]):
     def execute(self, sql: str, params: Mapping[str, Any] | None = None) -> duckdb.DuckDBPyConnection:
         """Execute a SQL statement, useful for DDL or imperative commands."""
         return self.connection.execute(sql, params)
+
+    def apply_schema(self, schema_path: str | Path | None = None) -> None:
+        """Apply the project schema from disk (defaults to ``schema.sql`` next to this module)."""
+
+        path = Path(schema_path) if schema_path is not None else Path(__file__).with_name("schema.sql")
+        schema_sql = path.read_text(encoding="utf-8")
+        self.connection.execute(schema_sql)
 
     def read_sql(self, sql: str, params: Mapping[str, Any] | None = None) -> DataFrame:
         """Run a SQL query and return the results as a pandas ``DataFrame``."""

--- a/src/nfl_pred/storage/schema.sql
+++ b/src/nfl_pred/storage/schema.sql
@@ -1,0 +1,60 @@
+-- DuckDB schema definitions for core prediction artifacts.
+-- The canonical keys across tables include season, week, game_id, and snapshot timestamps.
+
+CREATE TABLE IF NOT EXISTS features (
+    season INTEGER NOT NULL,
+    week INTEGER NOT NULL,
+    game_id VARCHAR NOT NULL,
+    team_side VARCHAR NOT NULL,
+    asof_ts TIMESTAMP NOT NULL,
+    snapshot_at TIMESTAMP NOT NULL,
+    feature_set VARCHAR NOT NULL,
+    payload_json VARCHAR NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (season, week, game_id, team_side, asof_ts)
+);
+
+CREATE INDEX IF NOT EXISTS idx_features_lookup
+    ON features (season, week, game_id, snapshot_at);
+
+CREATE TABLE IF NOT EXISTS predictions (
+    game_id VARCHAR NOT NULL,
+    season INTEGER NOT NULL,
+    week INTEGER NOT NULL,
+    asof_ts TIMESTAMP NOT NULL,
+    p_home_win DOUBLE,
+    p_away_win DOUBLE,
+    pick VARCHAR,
+    confidence DOUBLE,
+    model_id VARCHAR NOT NULL,
+    snapshot_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (game_id, season, week, asof_ts, model_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_predictions_lookup
+    ON predictions (season, week, game_id, snapshot_at);
+
+CREATE TABLE IF NOT EXISTS reports (
+    season INTEGER NOT NULL,
+    week INTEGER NOT NULL,
+    asof_ts TIMESTAMP NOT NULL,
+    metric VARCHAR NOT NULL,
+    value DOUBLE,
+    snapshot_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (season, week, asof_ts, metric)
+);
+
+CREATE INDEX IF NOT EXISTS idx_reports_lookup
+    ON reports (season, week, snapshot_at);
+
+CREATE TABLE IF NOT EXISTS runs_meta (
+    run_id VARCHAR NOT NULL,
+    model_id VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    params_json VARCHAR,
+    metrics_json VARCHAR,
+    PRIMARY KEY (run_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_meta_model
+    ON runs_meta (model_id, created_at);


### PR DESCRIPTION
## Summary
- add canonical DuckDB DDL covering features, predictions, reports, and run metadata tables with supporting indices
- extend the DuckDB client helper with an apply_schema utility to load the shared schema file

## Testing
- PYTHONPATH=src python - <<'PY'
from pathlib import Path
from tempfile import TemporaryDirectory

from nfl_pred.storage.duckdb_client import DuckDBClient

with TemporaryDirectory() as tmpdir:
    db_path = Path(tmpdir) / "test.db"
    with DuckDBClient(str(db_path)) as client:
        client.apply_schema()
        tables = client.read_sql(
            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' ORDER BY table_name"
        )
        print(tables)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d00cb745a8832f8e3a10c57231d101