### PR TITLE
[AI-010] Add ingestion data contracts

### DIFF
--- a/src/nfl_pred/ingest/__init__.py
+++ b/src/nfl_pred/ingest/__init__.py
@@ -1,7 +1,22 @@
-"""Ingestion entrypoints for nfl_pred."""
+"""Ingestion entrypoints and data contracts for :mod:`nfl_pred`."""
 
+from .contracts import (
+    assert_pbp_contract,
+    assert_roster_contract,
+    assert_schedule_contract,
+    assert_team_contract,
+)
 from .pbp import ingest_pbp
 from .rosters import ingest_rosters, ingest_teams
 from .schedules import ingest_schedules
 
-__all__ = ["ingest_schedules", "ingest_pbp", "ingest_rosters", "ingest_teams"]
+__all__ = [
+    "assert_schedule_contract",
+    "assert_pbp_contract",
+    "assert_roster_contract",
+    "assert_team_contract",
+    "ingest_schedules",
+    "ingest_pbp",
+    "ingest_rosters",
+    "ingest_teams",
+]

--- a/src/nfl_pred/ingest/contracts.py
+++ b/src/nfl_pred/ingest/contracts.py
@@ -1,0 +1,169 @@
+"""Dataframe contract helpers for ingestion datasets.
+
+This module provides simple column-level assertions for the raw datasets
+retrieved via :mod:`nflreadpy`.  The goal is to guard downstream code against
+upstream schema drift by ensuring the minimum viable column sets required by
+feature builders remain available before any heavy processing begins.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+
+SCHEDULE_REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "game_id",
+        "season",
+        "week",
+        "game_type",
+        "gameday",
+        "gametime",
+        "weekday",
+        "home_team",
+        "away_team",
+        "home_score",
+        "away_score",
+        "location",
+        "stadium",
+        "surface",
+        "roof",
+        "neutral_site",
+    }
+)
+
+
+PBP_REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "game_id",
+        "play_id",
+        "season",
+        "week",
+        "posteam",
+        "defteam",
+        "play_type",
+        "yards_gained",
+        "epa",
+        "air_yards",
+        "success",
+        "down",
+        "pass",
+        "rush",
+        "play_action",
+        "shotgun",
+        "no_huddle",
+        "sack",
+        "penalty",
+        "touchdown",
+        "posteam_score",
+        "defteam_score",
+        "score_differential",
+        "half_seconds_remaining",
+    }
+)
+
+
+ROSTER_REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "player_id",
+        "gsis_id",
+        "season",
+        "team",
+        "position",
+        "depth_chart_position",
+        "status",
+        "full_name",
+    }
+)
+
+
+TEAM_REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "team_abbr",
+        "team_name",
+        "team_id",
+        "conference",
+        "division",
+        "full_name",
+    }
+)
+
+
+def _assert_columns(
+    df: pd.DataFrame,
+    required: Iterable[str],
+    dataset_name: str,
+) -> None:
+    """Raise ``ValueError`` if ``required`` columns are missing from ``df``.
+
+    Args:
+        df: Dataframe returned by an ingestion routine.
+        required: Iterable of column names that must exist on ``df``.
+        dataset_name: Human-friendly dataset label used in error messages.
+
+    Raises:
+        ValueError: When any required column is absent.
+    """
+
+    present_columns = set(df.columns)
+    missing = set(required) - present_columns
+    if not missing:
+        return
+
+    sample_present = sorted(present_columns)[:5]
+    sample_display = ", ".join(sample_present) if sample_present else "<no columns>"
+    missing_display = ", ".join(sorted(missing))
+    raise ValueError(
+        f"{dataset_name} missing required columns: {missing_display}. "
+        f"Present columns include: {sample_display}."
+    )
+
+
+def assert_schedule_contract(df: pd.DataFrame) -> None:
+    """Validate that schedule dataframes include critical columns.
+
+    Parameters
+    ----------
+    df:
+        Schedule dataframe returned by :func:`nflreadpy.load_schedules`.
+
+    Raises
+    ------
+    ValueError
+        If any of the minimum viable schedule columns are missing.
+    """
+
+    _assert_columns(df, SCHEDULE_REQUIRED_COLUMNS, "Schedule dataset")
+
+
+def assert_pbp_contract(df: pd.DataFrame) -> None:
+    """Validate that play-by-play dataframes include critical columns."""
+
+    _assert_columns(df, PBP_REQUIRED_COLUMNS, "Play-by-play dataset")
+
+
+def assert_roster_contract(df: pd.DataFrame) -> None:
+    """Validate that roster dataframes include critical columns."""
+
+    _assert_columns(df, ROSTER_REQUIRED_COLUMNS, "Roster dataset")
+
+
+def assert_team_contract(df: pd.DataFrame) -> None:
+    """Validate that team metadata dataframes include critical columns."""
+
+    _assert_columns(df, TEAM_REQUIRED_COLUMNS, "Team metadata dataset")
+
+
+__all__ = [
+    "SCHEDULE_REQUIRED_COLUMNS",
+    "PBP_REQUIRED_COLUMNS",
+    "ROSTER_REQUIRED_COLUMNS",
+    "TEAM_REQUIRED_COLUMNS",
+    "assert_schedule_contract",
+    "assert_pbp_contract",
+    "assert_roster_contract",
+    "assert_team_contract",
+]
+

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,72 @@
+"""Unit-like checks for ingestion data contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Ensure the package source is importable without installing the project.
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from nfl_pred.ingest.contracts import (
+    PBP_REQUIRED_COLUMNS,
+    ROSTER_REQUIRED_COLUMNS,
+    SCHEDULE_REQUIRED_COLUMNS,
+    TEAM_REQUIRED_COLUMNS,
+    assert_pbp_contract,
+    assert_roster_contract,
+    assert_schedule_contract,
+    assert_team_contract,
+)
+
+
+def _frame_with_columns(columns: set[str]) -> pd.DataFrame:
+    """Return a tiny dataframe containing ``columns``."""
+
+    return pd.DataFrame({column: [0] for column in columns})
+
+
+@pytest.mark.parametrize(
+    ("columns", "validator"),
+    [
+        (SCHEDULE_REQUIRED_COLUMNS, assert_schedule_contract),
+        (PBP_REQUIRED_COLUMNS, assert_pbp_contract),
+        (ROSTER_REQUIRED_COLUMNS, assert_roster_contract),
+        (TEAM_REQUIRED_COLUMNS, assert_team_contract),
+    ],
+)
+def test_contract_validators_accept_complete_frames(columns: set[str], validator) -> None:
+    """Validators should no-op when provided all required columns."""
+
+    df = _frame_with_columns(set(columns) | {"extra"})
+    validator(df)
+
+
+@pytest.mark.parametrize(
+    ("columns", "missing", "validator"),
+    [
+        (SCHEDULE_REQUIRED_COLUMNS, "game_id", assert_schedule_contract),
+        (PBP_REQUIRED_COLUMNS, "play_id", assert_pbp_contract),
+        (ROSTER_REQUIRED_COLUMNS, "player_id", assert_roster_contract),
+        (TEAM_REQUIRED_COLUMNS, "team_abbr", assert_team_contract),
+    ],
+)
+def test_contract_validators_raise_on_missing(columns: set[str], missing: str, validator) -> None:
+    """Validators should raise ``ValueError`` when required columns are missing."""
+
+    partial_columns = set(columns) - {missing}
+    df = _frame_with_columns(partial_columns)
+    with pytest.raises(ValueError) as exc:
+        validator(df)
+
+    message = str(exc.value)
+    assert missing in message
+    # Provide context by ensuring a present column snippet is included.
+    assert "Present columns" in message
+


### PR DESCRIPTION
## Summary
- add column-level contract definitions and validation helpers for schedules, play-by-play, rosters, and team metadata
- expose the new contract helpers from the ingest package init for easy reuse
- add lightweight pytest coverage to confirm passing frames and informative errors on missing columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d014eac8bc832f8012daa228284b74