### PR TITLE
AI-016: implement forward-chaining week splits

### DIFF
--- a/src/nfl_pred/model/__init__.py
+++ b/src/nfl_pred/model/__init__.py
@@ -1,0 +1,5 @@
+"""Modeling utilities for NFL prediction workflows."""
+
+from .splits import time_series_splits  # noqa: F401
+
+__all__ = ["time_series_splits"]

--- a/src/nfl_pred/model/splits.py
+++ b/src/nfl_pred/model/splits.py
@@ -1,0 +1,105 @@
+"""Cross-validation splits for forward-chaining NFL modeling experiments."""
+
+from __future__ import annotations
+
+from typing import Generator, Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def _sorted_unique(values: Iterable) -> pd.Index:
+    """Return a pandas ``Index`` of sorted unique values preserving dtype."""
+    series = pd.Series(values)
+    if series.isna().any():
+        raise ValueError("Group column contains null values, cannot build time-series splits.")
+    # ``mergesort`` is stable and works with datetime/int week identifiers.
+    return pd.Index(series.sort_values(kind="mergesort").unique())
+
+
+def time_series_splits(
+    df: pd.DataFrame,
+    group_col: str = "week",
+    n_splits: int | None = None,
+    min_train_weeks: int = 4,
+) -> Generator[Tuple[np.ndarray, np.ndarray], None, None]:
+    """Yield forward-chaining train/validation indices grouped by week.
+
+    Parameters
+    ----------
+    df:
+        Feature table containing one or more rows per team-week.
+    group_col:
+        Column that identifies the temporal grouping (defaults to ``"week"``).
+    n_splits:
+        Number of validation folds to generate. If ``None`` (default) the
+        function will create as many folds as possible while satisfying the
+        ``min_train_weeks`` constraint.
+    min_train_weeks:
+        Minimum number of distinct weeks to include in each training sample.
+
+    Yields
+    ------
+    Tuple[np.ndarray, np.ndarray]
+        Two numpy arrays containing the integer index locations for the train
+        and validation subsets, respectively.
+
+    Notes
+    -----
+    The generator enforces strictly increasing week order so that the
+    validation week contains only observations that occur after the training
+    weeks. Each fold uses one consecutive week for validation, preventing
+    information leakage from future games.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({
+    ...     "week": [1, 1, 2, 2, 3, 3, 4, 4],
+    ...     "team": ["A", "B", "A", "B", "A", "B", "A", "B"],
+    ... })
+    >>> splits = list(time_series_splits(df, n_splits=2, min_train_weeks=2))
+    >>> [df.loc[val_idx, "week"].unique().item() for _, val_idx in splits]
+    [3, 4]
+    >>> [df.loc[train_idx, "week"].unique().tolist() for train_idx, _ in splits]
+    [[1, 2], [1, 2, 3]]
+    """
+
+    if group_col not in df.columns:
+        raise KeyError(f"Column '{group_col}' not present in DataFrame.")
+    if min_train_weeks < 1:
+        raise ValueError("min_train_weeks must be at least 1.")
+
+    unique_weeks = _sorted_unique(df[group_col])
+    total_weeks = len(unique_weeks)
+    if total_weeks <= min_train_weeks:
+        raise ValueError(
+            "Not enough distinct weeks to satisfy the minimum training window."
+        )
+
+    max_possible_splits = total_weeks - min_train_weeks
+    if n_splits is None:
+        splits_to_yield = max_possible_splits
+    elif n_splits <= 0:
+        raise ValueError("n_splits must be positive when provided.")
+    else:
+        if n_splits > max_possible_splits:
+            raise ValueError(
+                "Requested number of splits exceeds available validation weeks."
+            )
+        splits_to_yield = n_splits
+
+    for fold in range(splits_to_yield):
+        train_weeks = unique_weeks[: min_train_weeks + fold]
+        val_week = unique_weeks[min_train_weeks + fold]
+
+        train_mask = df[group_col].isin(train_weeks)
+        val_mask = df[group_col] == val_week
+
+        train_idx = df.index[train_mask].to_numpy()
+        val_idx = df.index[val_mask].to_numpy()
+
+        if len(val_idx) == 0:
+            raise ValueError(f"Validation week {val_week!r} has no rows.")
+
+        yield train_idx, val_idx

--- a/tests/test_model_splits.py
+++ b/tests/test_model_splits.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+
+from nfl_pred.model.splits import time_series_splits
+
+
+def _collect_weeks(df, indices):
+    return sorted(df.loc[indices, "week"].unique())
+
+
+def test_time_series_splits_forward_chaining():
+    df = pd.DataFrame(
+        {
+            "week": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
+            "team": ["A", "B", "A", "B", "A", "B", "A", "B", "A", "B"],
+        }
+    )
+
+    folds = list(time_series_splits(df, n_splits=2, min_train_weeks=2))
+    assert len(folds) == 2
+
+    for i, (train_idx, val_idx) in enumerate(folds):
+        train_weeks = _collect_weeks(df, train_idx)
+        val_weeks = _collect_weeks(df, val_idx)
+
+        assert len(val_weeks) == 1
+        assert val_weeks[0] == 3 + i
+        # Ensure all training weeks precede the validation week.
+        assert max(train_weeks) < val_weeks[0]
+        # Ensure training accumulates monotonically.
+        if i > 0:
+            prev_train_weeks = _collect_weeks(df, folds[i - 1][0])
+            assert prev_train_weeks == train_weeks[: len(prev_train_weeks)]
+
+
+def test_time_series_splits_allows_full_range_when_n_splits_none():
+    df = pd.DataFrame({"week": [1, 1, 2, 3, 3, 4], "team": list("ABCDEF")})
+
+    folds = list(time_series_splits(df, n_splits=None, min_train_weeks=2))
+    # Weeks available for validation: 3 and 4 -> 2 folds.
+    assert len(folds) == 2
+    val_weeks = [_collect_weeks(df, val_idx)[0] for _, val_idx in folds]
+    assert val_weeks == [3, 4]
+
+
+def test_time_series_splits_raises_when_insufficient_history():
+    df = pd.DataFrame({"week": [1, 1, 2, 2], "team": list("ABCD")})
+
+    with pytest.raises(ValueError):
+        list(time_series_splits(df, n_splits=1, min_train_weeks=3))


### PR DESCRIPTION
## Summary
- add `nfl_pred.model` package with a documented `time_series_splits` generator for grouped week folds
- ensure splits respect chronological order and configurable history length
- add unit tests covering monotonic folds, automatic split counts, and error handling

## Testing
- PYTHONPATH=src pytest tests/test_model_splits.py

------
https://chatgpt.com/codex/tasks/task_e_68d022e5d1e8832fa6c810ebe18bbf07