### PR TITLE
AI-018: implement Platt calibrator

### DIFF
--- a/src/nfl_pred/model/__init__.py
+++ b/src/nfl_pred/model/__init__.py
@@ -1,6 +1,7 @@
 """Modeling utilities for NFL prediction workflows."""
 
 from .baseline import BaselineClassifier  # noqa: F401
+from .calibration import PlattCalibrator  # noqa: F401
 from .splits import time_series_splits  # noqa: F401
 
-__all__ = ["BaselineClassifier", "time_series_splits"]
+__all__ = ["BaselineClassifier", "PlattCalibrator", "time_series_splits"]

--- a/src/nfl_pred/model/calibration.py
+++ b/src/nfl_pred/model/calibration.py
@@ -1,0 +1,149 @@
+"""Platt scaling calibration utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+
+def _as_1d_array(values: Iterable[Any]) -> np.ndarray:
+    """Convert ``values`` into a contiguous one-dimensional array."""
+
+    arr = np.asarray(list(values))
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+    if arr.ndim > 1:
+        arr = arr.ravel()
+    return arr
+
+
+@dataclass
+class CalibrationParams:
+    """Parameters learned by the Platt calibrator."""
+
+    slope: float
+    intercept: float
+
+
+class PlattCalibrator:
+    """Apply Platt scaling to a binary classifier."""
+
+    def __init__(
+        self,
+        *,
+        clip: float = 1e-6,
+        max_iter: int = 200,
+        solver: str = "lbfgs",
+    ) -> None:
+        if clip <= 0 or clip >= 0.5:
+            raise ValueError("clip must be in the interval (0, 0.5).")
+
+        self.clip = clip
+        self.max_iter = max_iter
+        self.solver = solver
+
+        self._base_model: Any | None = None
+        self._params: CalibrationParams | None = None
+        self._classes: np.ndarray | None = None
+        self._positive_index: int | None = None
+
+    def fit(
+        self,
+        base_model: Any,
+        X_valid: Any,
+        y_valid: Iterable[Any],
+    ) -> "PlattCalibrator":
+        """Fit the calibrator using validation data."""
+
+        if not hasattr(base_model, "predict_proba"):
+            raise TypeError("base_model must implement predict_proba().")
+
+        probs = np.asarray(base_model.predict_proba(X_valid))
+        if probs.ndim != 2 or probs.shape[1] != 2:
+            raise ValueError("PlattCalibrator requires binary probabilities with two columns.")
+
+        if hasattr(base_model, "classes_"):
+            classes = np.asarray(base_model.classes_)
+            if classes.shape[0] != 2:
+                raise ValueError("PlattCalibrator only supports binary classifiers.")
+        else:
+            classes = np.array([0, 1])
+
+        if 1 in classes:
+            positive_index = int(np.where(classes == 1)[0][0])
+        else:
+            positive_index = 1
+
+        y_array = _as_1d_array(y_valid)
+        if y_array.size != probs.shape[0]:
+            raise ValueError("X_valid and y_valid must contain the same number of rows.")
+
+        positive_probs = probs[:, positive_index]
+        clipped = np.clip(positive_probs, self.clip, 1 - self.clip)
+        logits = np.log(clipped / (1 - clipped)).reshape(-1, 1)
+
+        model = LogisticRegression(
+            solver=self.solver,
+            max_iter=self.max_iter,
+        )
+        model.fit(logits, y_array)
+
+        self._base_model = base_model
+        self._params = CalibrationParams(
+            slope=float(model.coef_[0, 0]),
+            intercept=float(model.intercept_[0]),
+        )
+        self._classes = classes
+        self._positive_index = positive_index
+        return self
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        """Return calibrated probabilities for ``X``."""
+
+        self._ensure_fitted()
+        assert self._base_model is not None
+        assert self._params is not None
+        assert self._positive_index is not None
+
+        base_probs = np.asarray(self._base_model.predict_proba(X))
+        if base_probs.ndim != 2 or base_probs.shape[1] != 2:
+            raise ValueError("PlattCalibrator requires binary probabilities with two columns.")
+
+        positive_probs = base_probs[:, self._positive_index]
+        clipped = np.clip(positive_probs, self.clip, 1 - self.clip)
+        logits = np.log(clipped / (1 - clipped))
+
+        calibrated_positive = 1 / (1 + np.exp(-(self._params.slope * logits + self._params.intercept)))
+        calibrated = base_probs.copy()
+        calibrated[:, self._positive_index] = calibrated_positive
+        calibrated[:, 1 - self._positive_index] = 1 - calibrated_positive
+        return calibrated
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Predict class labels using calibrated probabilities."""
+
+        probs = self.predict_proba(X)
+        return (probs[:, self._positive_index] >= 0.5).astype(int)
+
+    @property
+    def calibration_params(self) -> CalibrationParams:
+        """Return the learned calibration parameters."""
+
+        self._ensure_fitted()
+        assert self._params is not None
+        return self._params
+
+    @property
+    def classes_(self) -> np.ndarray:
+        """Return the class ordering used by the calibrator."""
+
+        self._ensure_fitted()
+        assert self._classes is not None
+        return self._classes
+
+    def _ensure_fitted(self) -> None:
+        if self._params is None or self._base_model is None or self._positive_index is None:
+            raise RuntimeError("PlattCalibrator must be fitted before use.")

--- a/tests/test_model_calibration.py
+++ b/tests/test_model_calibration.py
@@ -1,0 +1,68 @@
+"""Tests for Platt calibration utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.metrics import brier_score_loss
+
+from nfl_pred.model.calibration import PlattCalibrator
+
+
+def _sigmoid(z: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+class MisCalibratedModel:
+    """Deterministic classifier with intentionally skewed probabilities."""
+
+    def __init__(self, weights: np.ndarray) -> None:
+        self.weights = weights
+        self.classes_ = np.array([0, 1])
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        logits = X @ self.weights
+        base = _sigmoid(logits)
+        distorted = np.clip(base**2, 1e-6, 1 - 1e-6)
+        return np.column_stack([1 - distorted, distorted])
+
+
+def test_platt_calibrator_reduces_brier_score() -> None:
+    rng = np.random.default_rng(123)
+    n_samples = 600
+    X = rng.normal(size=(n_samples, 3))
+    true_weights = np.array([0.5, -1.25, 0.75])
+    probabilities = _sigmoid(X @ true_weights)
+    y = rng.binomial(1, probabilities)
+
+    base_model = MisCalibratedModel(true_weights)
+
+    X_valid, y_valid = X[:200], y[:200]
+    X_test, y_test = X[200:], y[200:]
+
+    calibrator = PlattCalibrator()
+    calibrator.fit(base_model, X_valid, y_valid)
+
+    base_probs = base_model.predict_proba(X_test)[:, 1]
+    calibrated_probs = calibrator.predict_proba(X_test)[:, 1]
+
+    base_brier = brier_score_loss(y_test, base_probs)
+    calibrated_brier = brier_score_loss(y_test, calibrated_probs)
+
+    assert calibrated_brier < base_brier
+
+
+def test_platt_calibrator_requires_fit() -> None:
+    base_model = MisCalibratedModel(np.array([1.0, -0.5]))
+    calibrator = PlattCalibrator()
+
+    with pytest.raises(RuntimeError):
+        _ = calibrator.predict_proba(np.zeros((2, 2)))
+
+    X_valid = np.zeros((4, 2))
+    y_valid = np.array([0, 1, 0, 1])
+
+    calibrator.fit(base_model, X_valid, y_valid)
+    probs = calibrator.predict_proba(np.zeros((3, 2)))
+    assert probs.shape == (3, 2)
+    assert np.allclose(probs.sum(axis=1), 1.0)


### PR DESCRIPTION
## Summary
- add a PlattCalibrator that fits a logistic mapping on held-out validation outputs and exposes calibrated probabilities
- export the calibrator alongside existing modeling utilities for downstream pipelines
- cover calibration with unit tests that confirm improved Brier score and basic guardrails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0476a22f4832fac94ebc3c9bc4a81