### PR TITLE
AI-021: add pick confidence tiers

### DIFF
--- a/src/nfl_pred/picks.py
+++ b/src/nfl_pred/picks.py
@@ -1,0 +1,103 @@
+"""Utilities for deriving picks and confidence tiers from win probabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+import pandas as pd
+
+STRONG_THRESHOLD: Final[float] = 0.65
+LEAN_THRESHOLD: Final[float] = 0.55
+
+
+@dataclass(frozen=True)
+class ConfidenceThresholds:
+    """Configuration container for pick confidence tiers."""
+
+    strong: float = STRONG_THRESHOLD
+    lean: float = LEAN_THRESHOLD
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(self.strong) or not np.isfinite(self.lean):
+            raise ValueError("Confidence thresholds must be finite numeric values.")
+        if self.strong < self.lean:
+            raise ValueError("Strong threshold must be greater than or equal to the lean threshold.")
+        if self.lean <= 0:
+            raise ValueError("Lean threshold must be positive.")
+
+
+def assign_pick_confidence(
+    frame: pd.DataFrame,
+    *,
+    home_column: str = "p_home_win",
+    away_column: str = "p_away_win",
+    thresholds: ConfidenceThresholds | None = None,
+    prefer_home_on_tie: bool = True,
+) -> pd.DataFrame:
+    """Return a new DataFrame with pick and confidence tier columns.
+
+    Parameters
+    ----------
+    frame:
+        DataFrame containing home/away win probabilities for each game.
+    home_column, away_column:
+        Column names holding the win probabilities for the home and away teams.
+    thresholds:
+        Optional :class:`ConfidenceThresholds` to customize Strong/Lean cutoffs.
+    prefer_home_on_tie:
+        When ``True`` (default) ties are resolved in favour of the home team; when
+        ``False`` ties favour the away team.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Copy of ``frame`` with two new columns:
+
+        ``pick``
+            Either ``"home"`` or ``"away"`` indicating the selected side.
+        ``confidence``
+            One of ``"Strong"``, ``"Lean"`` or ``"Pass"`` describing the pick tier.
+
+    Notes
+    -----
+    Probabilities that are missing or non-finite default to 0.5 so that the game is
+    treated as a coin flip. Ties are broken deterministically according to
+    ``prefer_home_on_tie`` to satisfy the repository's repeatability requirement.
+    """
+
+    if thresholds is None:
+        thresholds = ConfidenceThresholds()
+
+    missing_columns = {home_column, away_column} - set(frame.columns)
+    if missing_columns:
+        missing = ", ".join(sorted(missing_columns))
+        raise KeyError(f"Frame missing required probability columns: {missing}.")
+
+    result = frame.copy()
+
+    home_probs = pd.to_numeric(result[home_column], errors="coerce").to_numpy(dtype=float)
+    away_probs = pd.to_numeric(result[away_column], errors="coerce").to_numpy(dtype=float)
+
+    home_probs = np.nan_to_num(home_probs, nan=0.5, posinf=0.5, neginf=0.5)
+    away_probs = np.nan_to_num(away_probs, nan=0.5, posinf=0.5, neginf=0.5)
+
+    if prefer_home_on_tie:
+        pick = np.where(home_probs >= away_probs, "home", "away")
+    else:
+        pick = np.where(home_probs > away_probs, "home", "away")
+
+    max_probs = np.maximum(home_probs, away_probs)
+
+    confidence = np.full_like(max_probs, fill_value="Pass", dtype=object)
+    confidence[max_probs >= thresholds.lean] = "Lean"
+    confidence[max_probs >= thresholds.strong] = "Strong"
+
+    result["pick"] = pick
+    result["confidence"] = confidence
+
+    return result
+
+
+__all__ = ["ConfidenceThresholds", "assign_pick_confidence"]

--- a/src/nfl_pred/storage/schema.sql
+++ b/src/nfl_pred/storage/schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS predictions (
     p_home_win DOUBLE,
     p_away_win DOUBLE,
     pick VARCHAR,
-    confidence DOUBLE,
+    confidence VARCHAR,
     model_id VARCHAR NOT NULL,
     snapshot_at TIMESTAMP NOT NULL,
     PRIMARY KEY (game_id, season, week, asof_ts, model_id)

--- a/tests/test_picks.py
+++ b/tests/test_picks.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nfl_pred.picks import ConfidenceThresholds, assign_pick_confidence
+
+
+def test_assign_pick_confidence_applies_expected_tiers() -> None:
+    frame = pd.DataFrame(
+        {
+            "game_id": ["g1", "g2", "g3", "g4"],
+            "p_home_win": [0.70, 0.60, 0.54, 0.65],
+            "p_away_win": [0.30, 0.40, 0.46, 0.35],
+        }
+    )
+
+    result = assign_pick_confidence(frame)
+
+    assert list(result["pick"]) == ["home", "home", "home", "home"]
+    assert list(result["confidence"]) == ["Strong", "Lean", "Pass", "Strong"]
+
+
+def test_assign_pick_confidence_handles_ties_deterministically() -> None:
+    frame = pd.DataFrame(
+        {
+            "p_home_win": [0.50, 0.50],
+            "p_away_win": [0.50, 0.50],
+        }
+    )
+
+    home_pref = assign_pick_confidence(frame)
+    away_pref = assign_pick_confidence(frame, prefer_home_on_tie=False)
+
+    assert list(home_pref["pick"]) == ["home", "home"]
+    assert list(away_pref["pick"]) == ["away", "away"]
+
+
+def test_assign_pick_confidence_validates_columns() -> None:
+    frame = pd.DataFrame({"p_home_win": [0.6]})
+
+    with pytest.raises(KeyError):
+        assign_pick_confidence(frame)
+
+
+def test_threshold_configuration_enforces_ordering() -> None:
+    with pytest.raises(ValueError):
+        ConfidenceThresholds(strong=0.50, lean=0.55)
+
+    thresholds = ConfidenceThresholds(strong=0.7, lean=0.6)
+
+    frame = pd.DataFrame({"p_home_win": [0.65], "p_away_win": [0.35]})
+    result = assign_pick_confidence(frame, thresholds=thresholds)
+    assert result.loc[0, "confidence"] == "Lean"


### PR DESCRIPTION
## Summary
- add a dedicated `assign_pick_confidence` helper to derive picks and Strong/Lean/Pass tiers
- update inference pipeline to reuse the helper and persist tiers in the canonical column order
- align DuckDB schema with string confidence tiers and cover the helper with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d04f5b5610832f893ca1cda87e88b0