### PR TITLE
AI-022: add reporting metrics and reliability utilities

### DIFF
--- a/src/nfl_pred/reporting/__init__.py
+++ b/src/nfl_pred/reporting/__init__.py
@@ -1,0 +1,21 @@
+"""Reporting utilities for evaluation metrics and reliability analysis."""
+
+from .metrics import (
+    MetricsResult,
+    ReliabilityBin,
+    compute_classification_metrics,
+    compute_reliability_table,
+    plot_reliability_curve,
+    save_metrics_report,
+    save_reliability_report,
+)
+
+__all__ = [
+    "MetricsResult",
+    "ReliabilityBin",
+    "compute_classification_metrics",
+    "compute_reliability_table",
+    "plot_reliability_curve",
+    "save_metrics_report",
+    "save_reliability_report",
+]

--- a/src/nfl_pred/reporting/metrics.py
+++ b/src/nfl_pred/reporting/metrics.py
@@ -1,0 +1,240 @@
+"""Evaluation metrics and reliability reporting helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import mlflow
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+from sklearn.metrics import brier_score_loss, log_loss
+
+
+@dataclass(frozen=True)
+class MetricsResult:
+    """Container for aggregated classification metrics."""
+
+    brier_score: float
+    log_loss: float
+    n_observations: int
+
+
+@dataclass(frozen=True)
+class ReliabilityBin:
+    """Summary statistics for a single reliability bin."""
+
+    lower: float
+    upper: float
+    midpoint: float
+    count: int
+    predicted_mean: float
+    observed_rate: float
+
+
+_DEFAULT_BINS = np.linspace(0.0, 1.0, 11)
+_EPSILON = 1e-6
+
+
+def compute_classification_metrics(
+    df: pd.DataFrame,
+    *,
+    probability_column: str,
+    label_column: str,
+    group_columns: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Compute Brier score and log-loss overall or grouped by columns."""
+
+    if probability_column not in df.columns:
+        raise KeyError(f"Probability column '{probability_column}' missing from DataFrame.")
+    if label_column not in df.columns:
+        raise KeyError(f"Label column '{label_column}' missing from DataFrame.")
+
+    working = df[[probability_column, label_column]].copy()
+    working[label_column] = working[label_column].astype(int)
+
+    if group_columns:
+        missing = [column for column in group_columns if column not in df.columns]
+        if missing:
+            raise KeyError(f"Group columns missing from DataFrame: {missing}")
+        grouped = df[list(group_columns) + [probability_column, label_column]].copy()
+        metrics = (
+            grouped.groupby(list(group_columns), dropna=False)[[probability_column, label_column]]
+            .apply(_compute_metrics_for_slice, probability_column, label_column)
+            .reset_index()
+        )
+    else:
+        metrics = _compute_metrics_for_slice(working, probability_column, label_column)
+        metrics = metrics.to_frame().T
+
+    return metrics
+
+
+def _compute_metrics_for_slice(
+    frame: pd.DataFrame,
+    probability_column: str,
+    label_column: str,
+) -> pd.Series:
+    if frame.empty:
+        raise ValueError("Cannot compute metrics on empty slice.")
+
+    probs = _clip_probabilities(frame[probability_column].to_numpy(dtype=float))
+    labels = frame[label_column].to_numpy(dtype=int)
+
+    brier = float(brier_score_loss(labels, probs))
+    logl = float(log_loss(labels, probs, labels=[0, 1]))
+
+    return pd.Series(
+        {
+            "brier_score": brier,
+            "log_loss": logl,
+            "n_observations": int(len(frame)),
+        }
+    )
+
+
+def compute_reliability_table(
+    df: pd.DataFrame,
+    *,
+    probability_column: str,
+    label_column: str,
+    bins: Iterable[float] | None = None,
+) -> pd.DataFrame:
+    """Return reliability bin statistics using deterministic bin edges."""
+
+    if probability_column not in df.columns:
+        raise KeyError(f"Probability column '{probability_column}' missing from DataFrame.")
+    if label_column not in df.columns:
+        raise KeyError(f"Label column '{label_column}' missing from DataFrame.")
+
+    working = df[[probability_column, label_column]].copy()
+    working[label_column] = working[label_column].astype(int)
+
+    bin_edges = np.asarray(list(bins) if bins is not None else _DEFAULT_BINS, dtype=float)
+    if bin_edges.ndim != 1 or bin_edges.size < 2:
+        raise ValueError("Bins must define at least two monotonically increasing edges.")
+    if not np.all(np.diff(bin_edges) > 0):
+        raise ValueError("Bin edges must be strictly increasing.")
+
+    clipped_probs = _clip_probabilities(working[probability_column].to_numpy(dtype=float))
+    indices = np.digitize(clipped_probs, bin_edges, right=True)
+
+    records: list[dict[str, float | int]] = []
+    for bin_idx in range(1, bin_edges.size):
+        mask = indices == bin_idx
+        if not np.any(mask):
+            continue
+
+        lower = float(bin_edges[bin_idx - 1])
+        upper = float(bin_edges[bin_idx])
+        midpoint = float((lower + upper) / 2)
+        slice_probs = clipped_probs[mask]
+        slice_labels = working[label_column].to_numpy(dtype=int)[mask]
+
+        records.append(
+            {
+                "lower": lower,
+                "upper": upper,
+                "midpoint": midpoint,
+                "count": int(mask.sum()),
+                "predicted_mean": float(slice_probs.mean()),
+                "observed_rate": float(slice_labels.mean()),
+            }
+        )
+
+    reliability_df = pd.DataFrame.from_records(records, columns=[
+        "lower",
+        "upper",
+        "midpoint",
+        "count",
+        "predicted_mean",
+        "observed_rate",
+    ])
+
+    return reliability_df
+
+
+def plot_reliability_curve(reliability: pd.DataFrame, *, path: Path) -> Path:
+    """Create a reliability curve plot and persist it to ``path``."""
+
+    required_columns = {"midpoint", "observed_rate"}
+    if not required_columns.issubset(reliability.columns):
+        raise KeyError(
+            "Reliability DataFrame must contain columns: 'midpoint' and 'observed_rate'."
+        )
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    ax.plot([0, 1], [0, 1], linestyle="--", color="gray", label="Perfect")
+
+    if not reliability.empty:
+        ax.plot(
+            reliability["midpoint"],
+            reliability["observed_rate"],
+            marker="o",
+            label="Model",
+        )
+
+    ax.set_xlabel("Predicted win probability")
+    ax.set_ylabel("Empirical win rate")
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_title("Reliability Curve")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+
+    return path
+
+
+def save_metrics_report(metrics: pd.DataFrame, *, reports_dir: Path, name: str = "metrics.csv") -> Path:
+    """Persist metrics DataFrame to the reports directory and log to MLflow if active."""
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    output_path = reports_dir / name
+    metrics.to_csv(output_path, index=False)
+
+    active_run = mlflow.active_run()
+    if active_run is not None:
+        mlflow.log_artifact(str(output_path), artifact_path="reports")
+
+    return output_path
+
+
+def save_reliability_report(
+    reliability: pd.DataFrame,
+    *,
+    reports_dir: Path,
+    name: str = "reliability.csv",
+) -> Path:
+    """Persist reliability statistics and log to MLflow if an active run exists."""
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    output_path = reports_dir / name
+    reliability.to_csv(output_path, index=False)
+
+    active_run = mlflow.active_run()
+    if active_run is not None:
+        mlflow.log_artifact(str(output_path), artifact_path="reports")
+
+    return output_path
+
+
+def _clip_probabilities(values: Sequence[float]) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    return np.clip(array, _EPSILON, 1 - _EPSILON)
+
+
+__all__ = [
+    "MetricsResult",
+    "ReliabilityBin",
+    "compute_classification_metrics",
+    "compute_reliability_table",
+    "plot_reliability_curve",
+    "save_metrics_report",
+    "save_reliability_report",
+]

--- a/tests/test_reporting_metrics.py
+++ b/tests/test_reporting_metrics.py
@@ -1,0 +1,107 @@
+"""Tests for reporting metrics and reliability helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from nfl_pred.reporting.metrics import (
+    compute_classification_metrics,
+    compute_reliability_table,
+    plot_reliability_curve,
+)
+
+
+@pytest.fixture()
+def sample_predictions() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "season": [2023, 2023, 2023, 2023],
+            "week": [1, 1, 2, 2],
+            "prob": [0.8, 0.2, 0.65, 0.3],
+            "label": [1, 0, 1, 0],
+        }
+    )
+
+
+def test_compute_classification_metrics_overall(sample_predictions: pd.DataFrame) -> None:
+    metrics = compute_classification_metrics(
+        sample_predictions, probability_column="prob", label_column="label"
+    )
+
+    assert pytest.approx(metrics.loc[0, "brier_score"], rel=1e-6) == 0.073125
+    assert pytest.approx(metrics.loc[0, "log_loss"], rel=1e-6) == 0.308436
+    assert metrics.loc[0, "n_observations"] == 4
+
+
+def test_compute_classification_metrics_by_week(sample_predictions: pd.DataFrame) -> None:
+    metrics = compute_classification_metrics(
+        sample_predictions,
+        probability_column="prob",
+        label_column="label",
+        group_columns=["season", "week"],
+    )
+
+    assert set(metrics.columns) == {"season", "week", "brier_score", "log_loss", "n_observations"}
+    assert metrics.shape[0] == 2
+    week1 = metrics.loc[metrics["week"] == 1].iloc[0]
+    assert pytest.approx(week1["brier_score"], rel=1e-6) == 0.04
+    assert week1["n_observations"] == 2
+
+
+def test_compute_reliability_table_returns_expected_bins(sample_predictions: pd.DataFrame) -> None:
+    reliability = compute_reliability_table(
+        sample_predictions,
+        probability_column="prob",
+        label_column="label",
+        bins=np.linspace(0.0, 1.0, 6),
+    )
+
+    assert set(reliability.columns) == {
+        "lower",
+        "upper",
+        "midpoint",
+        "count",
+        "predicted_mean",
+        "observed_rate",
+    }
+    assert reliability["count"].sum() == len(sample_predictions)
+    # Highest bin should contain the high confidence win.
+    assert reliability.loc[reliability["upper"] == 0.8, "observed_rate"].iloc[0] == 1.0
+
+
+def test_plot_reliability_curve_creates_file(tmp_path: Path) -> None:
+    reliability = pd.DataFrame(
+        {
+            "midpoint": [0.1, 0.3, 0.5, 0.7, 0.9],
+            "observed_rate": [0.05, 0.25, 0.55, 0.7, 0.95],
+        }
+    )
+
+    output = plot_reliability_curve(reliability, path=tmp_path / "reliability.png")
+
+    assert output.exists()
+    assert output.stat().st_size > 0
+
+
+def test_compute_metrics_requires_columns(sample_predictions: pd.DataFrame) -> None:
+    with pytest.raises(KeyError):
+        compute_classification_metrics(
+            sample_predictions.drop(columns=["prob"]),
+            probability_column="prob",
+            label_column="label",
+        )
+
+
+def test_compute_reliability_requires_valid_bins(sample_predictions: pd.DataFrame) -> None:
+    with pytest.raises(ValueError):
+        compute_reliability_table(
+            sample_predictions,
+            probability_column="prob",
+            label_column="label",
+            bins=[0.0, 0.0, 1.0],
+        )
+


### PR DESCRIPTION
## Summary
- add reporting module with helpers to calculate grouped Brier/log-loss metrics and reliability tables
- provide persistence helpers that log reports to MLflow and generate calibration plots
- cover reporting utilities with unit tests, including reliability binning and plotting behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d05097f170832fada05e587e7d1a75