### PR TITLE
Add stadium reference dataset and loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ htmlcov/
 # Data and models (retain folders via .gitkeep)
 data/*
 !data/.gitkeep
+!data/ref/
+!data/ref/**
 
 # Artifacts
 dist/

--- a/data/ref/stadiums.csv
+++ b/data/ref/stadiums.csv
@@ -1,0 +1,31 @@
+venue,teams,lat,lon,tz,altitude_ft,surface,roof,neutral_site
+Allegiant Stadium,LV,36.09085,-115.18331,America/Los_Angeles,670,artificial_turf,dome,false
+Acrisure Stadium,PIT,40.446804,-80.015728,America/New_York,732,natural_grass,open,false
+AT&T Stadium,DAL,32.7473,-97.09451,America/Chicago,640,artificial_turf,retractable,false
+Bank of America Stadium,CAR,35.225805,-80.852861,America/New_York,748,natural_grass,open,false
+Caesars Superdome,NO,29.951061,-90.081254,America/Chicago,3,artificial_turf,dome,false
+Cleveland Browns Stadium,CLE,41.506053,-81.699564,America/New_York,584,natural_grass,open,false
+Empower Field at Mile High,DEN,39.743936,-105.020097,America/Denver,5280,natural_grass,open,false
+EverBank Stadium,JAX,30.323925,-81.637356,America/New_York,16,natural_grass,open,false
+FedExField,WAS,38.907701,-76.864517,America/New_York,338,natural_grass,open,false
+Ford Field,DET,42.339958,-83.045639,America/Detroit,610,artificial_turf,dome,false
+GEHA Field at Arrowhead Stadium,KC,39.048939,-94.483865,America/Chicago,1060,natural_grass,open,false
+Gillette Stadium,NE,42.090944,-71.264348,America/New_York,289,artificial_turf,open,false
+Hard Rock Stadium,MIA,25.958056,-80.238889,America/New_York,7,natural_grass,open,false
+Highmark Stadium,BUF,42.773758,-78.786837,America/New_York,751,natural_grass,open,false
+Lambeau Field,GB,44.501341,-88.062217,America/Chicago,640,natural_grass,open,false
+Levi's Stadium,SF,37.403,-121.9702,America/Los_Angeles,17,natural_grass,open,false
+Lincoln Financial Field,PHI,39.900771,-75.167468,America/New_York,26,natural_grass,open,false
+Lumen Field,SEA,47.595151,-122.331632,America/Los_Angeles,21,artificial_turf,open,false
+Lucas Oil Stadium,IND,39.760056,-86.163806,America/Indiana/Indianapolis,720,artificial_turf,retractable,false
+M&T Bank Stadium,BAL,39.278057,-76.622706,America/New_York,35,natural_grass,open,false
+Mercedes-Benz Stadium,ATL,33.755403,-84.400864,America/New_York,1020,artificial_turf,retractable,false
+MetLife Stadium,NYG|NYJ,40.813528,-74.074361,America/New_York,16,artificial_turf,open,false
+Nissan Stadium,TEN,36.166383,-86.77129,America/Chicago,466,natural_grass,open,false
+NRG Stadium,HOU,29.684722,-95.410833,America/Chicago,49,artificial_turf,retractable,false
+Paycor Stadium,CIN,39.095442,-84.516039,America/New_York,482,natural_grass,open,false
+Raymond James Stadium,TB,27.975967,-82.50335,America/New_York,26,natural_grass,open,false
+SoFi Stadium,LAC|LAR,33.953514,-118.338661,America/Los_Angeles,98,artificial_turf,indoors,false
+State Farm Stadium,ARI,33.527625,-112.262538,America/Phoenix,1070,natural_grass,retractable,false
+Soldier Field,CHI,41.862313,-87.616688,America/Chicago,587,natural_grass,open,false
+U.S. Bank Stadium,MIN,44.973489,-93.257128,America/Chicago,840,artificial_turf,dome,false

--- a/src/nfl_pred/ref/__init__.py
+++ b/src/nfl_pred/ref/__init__.py
@@ -1,0 +1,8 @@
+"""Reference data utilities for stadiums and weather context."""
+
+from .stadiums import load_stadiums, StadiumsValidationError
+
+__all__ = [
+    "load_stadiums",
+    "StadiumsValidationError",
+]

--- a/src/nfl_pred/ref/stadiums.py
+++ b/src/nfl_pred/ref/stadiums.py
@@ -1,0 +1,146 @@
+"""Helpers for loading and validating stadium reference data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from nfl_pred.config import load_config
+
+__all__ = ["StadiumsValidationError", "load_stadiums"]
+
+
+DATA_SUBPATH = Path("ref") / "stadiums.csv"
+REQUIRED_COLUMNS = (
+    "venue",
+    "teams",
+    "lat",
+    "lon",
+    "tz",
+    "altitude_ft",
+    "surface",
+    "roof",
+    "neutral_site",
+)
+ALLOWED_SURFACES = {"natural_grass", "artificial_turf"}
+ALLOWED_ROOF_TYPES = {"open", "dome", "retractable", "indoors"}
+
+
+@dataclass(frozen=True)
+class StadiumsValidationError(ValueError):
+    """Raised when the stadium reference table fails validation."""
+
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - dataclass convenience
+        return self.message
+
+
+def load_stadiums(data_dir: str | Path | None = None) -> pd.DataFrame:
+    """Load the authoritative stadium table and validate its contents."""
+    base_dir = Path(data_dir) if data_dir is not None else Path(load_config().paths.data_dir)
+    csv_path = base_dir / DATA_SUBPATH
+
+    if not csv_path.exists():
+        raise StadiumsValidationError(f"Stadium reference file not found: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+    _validate_schema(df)
+
+    df = df.copy()
+    df["teams"] = df["teams"].apply(_parse_teams)
+    df["neutral_site"] = df["neutral_site"].apply(_coerce_bool)
+
+    _validate_rows(df)
+
+    return df.sort_values("venue").reset_index(drop=True)
+
+
+def _validate_schema(df: pd.DataFrame) -> None:
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise StadiumsValidationError(
+            "Stadium reference is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+
+def _parse_teams(raw: str) -> tuple[str, ...]:
+    parts = [segment.strip() for segment in str(raw).split("|") if segment.strip()]
+    if not parts:
+        raise StadiumsValidationError("Stadium entry must include at least one team code.")
+    return tuple(parts)
+
+
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"true", "1"}:
+        return True
+    if text in {"false", "0"}:
+        return False
+    raise StadiumsValidationError(f"Invalid neutral_site flag: {value}")
+
+
+def _validate_rows(df: pd.DataFrame) -> None:
+    for column in ("lat", "lon"):
+        if not pd.api.types.is_numeric_dtype(df[column]):
+            raise StadiumsValidationError(f"Column '{column}' must be numeric.")
+
+    if (df["lat"].abs() > 90).any():
+        raise StadiumsValidationError("Latitude must be within [-90, 90].")
+    if (df["lon"].abs() > 180).any():
+        raise StadiumsValidationError("Longitude must be within [-180, 180].")
+
+    if not pd.api.types.is_numeric_dtype(df["altitude_ft"]):
+        raise StadiumsValidationError("Column 'altitude_ft' must be numeric.")
+
+    if (df["altitude_ft"] < -100).any():
+        raise StadiumsValidationError("Altitude appears invalid (below -100 ft).")
+
+    invalid_surfaces = set(df["surface"].unique()) - ALLOWED_SURFACES
+    if invalid_surfaces:
+        raise StadiumsValidationError(
+            "Unexpected surface types: " + ", ".join(sorted(invalid_surfaces))
+        )
+
+    invalid_roofs = set(df["roof"].unique()) - ALLOWED_ROOF_TYPES
+    if invalid_roofs:
+        raise StadiumsValidationError(
+            "Unexpected roof types: " + ", ".join(sorted(invalid_roofs))
+        )
+
+    invalid_tz: list[str] = []
+    for tz in df["tz"].unique():
+        try:
+            ZoneInfo(tz)
+        except ZoneInfoNotFoundError:
+            invalid_tz.append(tz)
+    if invalid_tz:
+        raise StadiumsValidationError(
+            "Invalid time zone identifiers: " + ", ".join(sorted(invalid_tz))
+        )
+
+    duplicate_venues = df["venue"].duplicated().any()
+    if duplicate_venues:
+        raise StadiumsValidationError("Duplicate venue names detected in stadium reference.")
+
+    duplicate_rows = df.duplicated(subset=["venue", "teams"]).any()
+    if duplicate_rows:
+        raise StadiumsValidationError("Duplicate venue/team combinations detected.")
+
+    empty_roof = df["roof"].astype(str).str.strip() == ""
+    if empty_roof.any():
+        raise StadiumsValidationError("Roof type cannot be blank.")
+
+    empty_surface = df["surface"].astype(str).str.strip() == ""
+    if empty_surface.any():
+        raise StadiumsValidationError("Surface cannot be blank.")
+
+    for venue, teams in zip(df["venue"], df["teams"]):
+        if any(len(team) == 0 for team in teams):
+            raise StadiumsValidationError(f"Venue '{venue}' has an empty team code.")
+

--- a/tests/test_stadiums.py
+++ b/tests/test_stadiums.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from nfl_pred.ref.stadiums import StadiumsValidationError, load_stadiums
+
+
+def test_load_stadiums_returns_validated_dataframe():
+    df = load_stadiums()
+
+    expected_columns = {
+        "venue",
+        "teams",
+        "lat",
+        "lon",
+        "tz",
+        "altitude_ft",
+        "surface",
+        "roof",
+        "neutral_site",
+    }
+    assert expected_columns.issubset(set(df.columns))
+
+    assert df["teams"].apply(lambda value: isinstance(value, tuple)).all()
+    shared_row = df.loc[df["venue"] == "SoFi Stadium"].iloc[0]
+    assert shared_row["teams"] == ("LAC", "LAR")
+
+    assert df["neutral_site"].dtype == bool
+    assert not df["neutral_site"].any()
+
+    assert (df["lat"].between(-90, 90)).all()
+    assert (df["lon"].between(-180, 180)).all()
+
+
+def test_load_stadiums_rejects_invalid_time_zone(tmp_path):
+    source = pd.read_csv("data/ref/stadiums.csv")
+    source.loc[0, "tz"] = "Mars/OlympusMons"
+
+    custom_data_dir = tmp_path / "data"
+    custom_data_dir.mkdir()
+    ref_dir = custom_data_dir / "ref"
+    ref_dir.mkdir()
+    source.to_csv(ref_dir / "stadiums.csv", index=False)
+
+    with pytest.raises(StadiumsValidationError):
+        load_stadiums(data_dir=custom_data_dir)


### PR DESCRIPTION
## Summary
- add an authoritative stadium reference CSV with location, timezone, surface, roof, and neutral site metadata
- implement a validated loader helper in `nfl_pred.ref.stadiums` for downstream consumers
- enable tracking of reference data files and add unit tests that cover the loader and failure cases

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0592cfe30832f809977335ffa6c1f