### PR TITLE
AI-103: add NWS client with caching and normalization

### DIFF
--- a/src/nfl_pred/weather/__init__.py
+++ b/src/nfl_pred/weather/__init__.py
@@ -1,0 +1,5 @@
+"""Weather-related utilities and clients."""
+
+from .nws_client import NWSClient, gridpoint_forecast, point_metadata
+
+__all__ = ["NWSClient", "gridpoint_forecast", "point_metadata"]

--- a/src/nfl_pred/weather/nws_client.py
+++ b/src/nfl_pred/weather/nws_client.py
@@ -1,0 +1,447 @@
+"""Client for interacting with the National Weather Service API."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, MutableMapping, Protocol
+
+import requests
+
+
+class ResponseProtocol(Protocol):
+    """Protocol describing the subset of ``requests.Response`` that we use."""
+
+    status_code: int
+    headers: Mapping[str, str]
+
+    def json(self) -> Any:  # pragma: no cover - interface declaration
+        """Return the decoded JSON payload."""
+
+
+class TransportProtocol(Protocol):
+    """Protocol describing the transport used by :class:`NWSClient`."""
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
+        timeout: float | tuple[float, float] | None = None,
+    ) -> ResponseProtocol:  # pragma: no cover - interface declaration
+        """Perform an HTTP request and return a response object."""
+
+
+RawStore = Callable[[str, Mapping[str, Any]], None]
+
+
+class NWSClientError(RuntimeError):
+    """Raised when the NWS API returns an unexpected response."""
+
+
+@dataclass
+class _CacheEntry:
+    expires_at: float
+    value: Any
+
+
+class _TTLCache:
+    """A minimal TTL cache used to memoize API responses."""
+
+    def __init__(self, ttl_seconds: float | None, now: Callable[[], float]) -> None:
+        self._ttl = ttl_seconds
+        self._now = now
+        self._store: MutableMapping[str, _CacheEntry] = {}
+
+    def get(self, key: str) -> Any | None:
+        if self._ttl is None:
+            return None
+
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+
+        if entry.expires_at <= self._now():
+            self._store.pop(key, None)
+            return None
+
+        return entry.value
+
+    def set(self, key: str, value: Any) -> None:
+        if self._ttl is None:
+            return
+
+        self._store[key] = _CacheEntry(expires_at=self._now() + self._ttl, value=value)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+_DEFAULT_USER_AGENT = "nfl-prediction/0.0 (+https://example.com)"
+
+
+class NWSClient:
+    """HTTP client that wraps the National Weather Service API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.weather.gov",
+        user_agent: str = _DEFAULT_USER_AGENT,
+        timeout: float = 10.0,
+        transport: TransportProtocol | None = None,
+        raw_store: RawStore | None = None,
+        metadata_cache_ttl: float | None = 6 * 60 * 60,
+        forecast_cache_ttl: float | None = 15 * 60,
+        max_retries: int = 3,
+        backoff_factor: float = 0.5,
+        sleep: Callable[[float], None] | None = None,
+        monotonic: Callable[[], float] | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._transport = transport
+        self._raw_store = raw_store
+        self._headers = {
+            "User-Agent": user_agent,
+            "Accept": "application/geo+json",
+        }
+        self._max_retries = max(1, max_retries)
+        self._backoff_factor = backoff_factor
+        self._sleep = sleep or time.sleep
+        self._now = monotonic or time.monotonic
+
+        self._point_cache = _TTLCache(metadata_cache_ttl, self._now)
+        self._forecast_cache = _TTLCache(forecast_cache_ttl, self._now)
+        self._session: requests.Session | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def point_metadata(self, lat: float, lon: float) -> dict[str, Any]:
+        """Return grid metadata for the provided latitude and longitude."""
+
+        cache_key = f"{lat:.4f},{lon:.4f}"
+        cached = self._point_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        path = f"points/{lat},{lon}"
+        payload = self._request_json(path)
+        normalized = _normalize_point_metadata(payload, lat, lon)
+        self._point_cache.set(cache_key, normalized)
+        return normalized
+
+    def gridpoint_forecast(
+        self,
+        wfo: str,
+        x: int,
+        y: int,
+        *,
+        hourly: bool = False,
+    ) -> dict[str, Any]:
+        """Return a normalized gridpoint forecast."""
+
+        suffix = "hourly" if hourly else "regular"
+        cache_key = f"{wfo.upper()}_{x}_{y}_{suffix}"
+        cached = self._forecast_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        endpoint = f"gridpoints/{wfo}/{x},{y}/forecast"
+        if hourly:
+            endpoint += "/hourly"
+
+        payload = self._request_json(endpoint)
+        normalized = _normalize_forecast(payload)
+        self._forecast_cache.set(cache_key, normalized)
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _request_json(
+        self,
+        endpoint: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        transport = self._transport or self._get_session()
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            response = transport.request(
+                "GET",
+                url,
+                headers=self._headers,
+                params=params,
+                timeout=self._timeout,
+            )
+
+            status = response.status_code
+            if status == 429 or 500 <= status < 600:
+                retry_after = _retry_after_seconds(response.headers)
+                if attempt >= self._max_retries - 1:
+                    break
+                self._sleep(retry_after or self._compute_backoff(attempt))
+                continue
+
+            if status >= 400:
+                last_error = NWSClientError(
+                    f"NWS API returned status {status} for endpoint '{endpoint}'."
+                )
+                break
+
+            payload = response.json()
+            if self._raw_store is not None:
+                try:
+                    self._raw_store(endpoint, payload)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            return payload
+
+        if last_error is None:
+            last_error = NWSClientError(
+                f"NWS API failed after {self._max_retries} attempts for '{endpoint}'."
+            )
+        raise last_error
+
+    def _get_session(self) -> requests.Session:
+        if self._session is None:
+            session = requests.Session()
+            session.headers.update(self._headers)
+            self._session = session
+        return self._session
+
+    def _compute_backoff(self, attempt: int) -> float:
+        # Exponential backoff with jitter-friendly minimum floor.
+        delay = self._backoff_factor * (2 ** attempt)
+        return max(0.1, delay)
+
+
+# ----------------------------------------------------------------------
+# Normalization helpers
+# ----------------------------------------------------------------------
+
+def _retry_after_seconds(headers: Mapping[str, str] | None) -> float | None:
+    if not headers:
+        return None
+
+    retry_after = headers.get("Retry-After")
+    if retry_after is None:
+        return None
+
+    try:
+        return float(retry_after)
+    except ValueError:
+        return None
+
+
+def _normalize_point_metadata(
+    payload: Mapping[str, Any], lat: float, lon: float
+) -> dict[str, Any]:
+    properties = payload.get("properties", {})
+    relative = properties.get("relativeLocation", {})
+    rel_props = relative.get("properties", {})
+    distance = rel_props.get("distance", {})
+
+    distance_m = _convert_length_to_meters(distance.get("value"), distance.get("unitCode"))
+    distance_miles = _meters_to_miles(distance_m) if distance_m is not None else None
+
+    normalized: dict[str, Any] = {
+        "input_latitude": lat,
+        "input_longitude": lon,
+        "grid_id": properties.get("gridId"),
+        "grid_x": properties.get("gridX"),
+        "grid_y": properties.get("gridY"),
+        "forecast_url": properties.get("forecast"),
+        "forecast_hourly_url": properties.get("forecastHourly"),
+        "observation_stations_url": properties.get("observationStations"),
+        "timezone": properties.get("timeZone"),
+        "city": rel_props.get("city"),
+        "state": rel_props.get("state"),
+        "relative_location": relative.get("geometry"),
+        "distance_m": distance_m,
+        "distance_miles": distance_miles,
+        "within_10_miles": distance_miles is not None and distance_miles <= 10.0,
+    }
+
+    return normalized
+
+
+def _normalize_forecast(payload: Mapping[str, Any]) -> dict[str, Any]:
+    properties = payload.get("properties", {})
+    elevation = properties.get("elevation", {})
+    elevation_m = _convert_length_to_meters(elevation.get("value"), elevation.get("unitCode"))
+
+    periods = []
+    for period in properties.get("periods", []) or []:
+        temperature_c = _normalize_temperature(period.get("temperature"), period.get("temperatureUnit"))
+        precip_prob = period.get("probabilityOfPrecipitation", {}) or {}
+        precip_value = precip_prob.get("value")
+        precip_unit = precip_prob.get("unitCode")
+        precip_pct = _convert_probability_to_percent(precip_value, precip_unit)
+
+        wind_speed_mps = _parse_wind_speed(period.get("windSpeed"))
+        wind_gust_mps = _parse_wind_speed(period.get("windGust"))
+
+        periods.append(
+            {
+                "number": period.get("number"),
+                "name": period.get("name"),
+                "start_time": period.get("startTime"),
+                "end_time": period.get("endTime"),
+                "is_daytime": period.get("isDaytime"),
+                "temperature_c": temperature_c,
+                "temperature_original": period.get("temperature"),
+                "short_forecast": period.get("shortForecast"),
+                "detailed_forecast": period.get("detailedForecast"),
+                "wind_direction": period.get("windDirection"),
+                "wind_speed_mps": wind_speed_mps,
+                "wind_speed": period.get("windSpeed"),
+                "wind_gust_mps": wind_gust_mps,
+                "wind_gust": period.get("windGust"),
+                "probability_of_precipitation_pct": precip_pct,
+            }
+        )
+
+    normalized = {
+        "updated_at": properties.get("updated"),
+        "generated_at": properties.get("generatedAt"),
+        "units": properties.get("units"),
+        "elevation_m": elevation_m,
+        "periods": periods,
+    }
+
+    return normalized
+
+
+def _normalize_temperature(value: Any, unit: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        temp = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if unit is None:
+        return temp
+
+    unit = unit.upper()
+    if unit == "F":
+        return (temp - 32.0) * (5.0 / 9.0)
+    if unit == "C":
+        return temp
+    if unit in {"K", "KELVIN"}:
+        return temp - 273.15
+    return temp
+
+
+def _parse_wind_speed(value: Any) -> float | None:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        mph = float(value)
+    else:
+        numbers = [float(match) for match in _FIND_NUMBER_PATTERN.findall(str(value))]
+        if not numbers:
+            return None
+        mph = sum(numbers) / len(numbers)
+
+    return mph * 0.44704
+
+
+def _convert_probability_to_percent(value: Any, unit: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        probability = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if unit is None:
+        return probability
+
+    unit = unit.lower()
+    if unit in {"wmoUnit:percent", "percent", "%"}:
+        return probability
+    if unit in {"wmoUnit:proportion", "proportion"}:
+        return probability * 100.0
+    return probability
+
+
+def _convert_length_to_meters(value: Any, unit: str | None) -> float | None:
+    if value is None:
+        return None
+
+    try:
+        magnitude = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    if unit is None:
+        return magnitude
+
+    unit = unit.lower()
+    if unit in {"wmounit:m", "m", "meter", "meters"}:
+        return magnitude
+    if unit in {"wmounit:km", "km", "kilometer", "kilometers"}:
+        return magnitude * 1000.0
+    if unit in {"wmounit:ft_us", "ft", "foot", "feet"}:
+        return magnitude * 0.3048
+    if unit in {"wmounit:mi_us", "mi", "mile", "miles"}:
+        return magnitude * 1609.344
+    return magnitude
+
+
+def _meters_to_miles(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return value / 1609.344
+
+
+_FIND_NUMBER_PATTERN = __import__("re").compile(r"\d+(?:\.\d+)?")
+
+
+# ----------------------------------------------------------------------
+# Module-level convenience wrappers
+# ----------------------------------------------------------------------
+
+_default_client: NWSClient | None = None
+
+
+def _get_default_client() -> NWSClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = NWSClient()
+    return _default_client
+
+
+def point_metadata(lat: float, lon: float, *, client: NWSClient | None = None) -> dict[str, Any]:
+    """Return point metadata using the shared :class:`NWSClient` instance."""
+
+    active_client = client or _get_default_client()
+    return active_client.point_metadata(lat, lon)
+
+
+def gridpoint_forecast(
+    wfo: str,
+    x: int,
+    y: int,
+    *,
+    hourly: bool = False,
+    client: NWSClient | None = None,
+) -> dict[str, Any]:
+    """Return gridpoint forecast using the shared :class:`NWSClient` instance."""
+
+    active_client = client or _get_default_client()
+    return active_client.gridpoint_forecast(wfo, x, y, hourly=hourly)
+
+
+__all__ = ["NWSClient", "point_metadata", "gridpoint_forecast", "NWSClientError"]

--- a/tests/test_weather_nws_client.py
+++ b/tests/test_weather_nws_client.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import pytest
+
+from nfl_pred.weather.nws_client import NWSClient, NWSClientError
+
+
+@dataclass
+class _StubResponse:
+    payload: Mapping[str, Any]
+    status_code: int = 200
+    headers: Mapping[str, str] | None = None
+
+    def json(self) -> Mapping[str, Any]:
+        return self.payload
+
+
+class _StubTransport:
+    def __init__(self, responses: dict[str, list[_StubResponse]]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+        params: Mapping[str, Any] | None = None,
+        timeout: float | tuple[float, float] | None = None,
+    ) -> _StubResponse:
+        self.calls.append(url)
+        try:
+            responses = self._responses[url]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AssertionError(f"Unexpected URL requested: {url}") from exc
+        if not responses:
+            raise AssertionError(f"No stub response remaining for {url}")
+        return responses.pop(0)
+
+
+POINT_PAYLOAD = {
+    "properties": {
+        "gridId": "LWX",
+        "gridX": 96,
+        "gridY": 70,
+        "forecast": "https://api.weather.gov/gridpoints/LWX/96,70/forecast",
+        "forecastHourly": "https://api.weather.gov/gridpoints/LWX/96,70/forecast/hourly",
+        "observationStations": "https://api.weather.gov/gridpoints/LWX/96,70/stations",
+        "timeZone": "America/New_York",
+        "relativeLocation": {
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-77.4705, 39.0438],
+            },
+            "properties": {
+                "distance": {"unitCode": "wmoUnit:m", "value": 8046.72},
+                "city": "Ashburn",
+                "state": "VA",
+            },
+        },
+    }
+}
+
+
+FORECAST_PAYLOAD = {
+    "properties": {
+        "updated": "2024-04-01T12:00:00+00:00",
+        "generatedAt": "2024-04-01T11:59:00+00:00",
+        "units": "us",
+        "elevation": {"unitCode": "wmoUnit:m", "value": 120.0},
+        "periods": [
+            {
+                "number": 1,
+                "name": "Today",
+                "startTime": "2024-04-01T13:00:00+00:00",
+                "endTime": "2024-04-01T19:00:00+00:00",
+                "isDaytime": True,
+                "temperature": 70,
+                "temperatureUnit": "F",
+                "shortForecast": "Sunny",
+                "detailedForecast": "Sunny with light winds",
+                "windSpeed": "5 to 10 mph",
+                "windGust": "20 mph",
+                "windDirection": "SW",
+                "probabilityOfPrecipitation": {"unitCode": "wmoUnit:percent", "value": 10},
+            },
+            {
+                "number": 2,
+                "name": "Tonight",
+                "startTime": "2024-04-01T19:00:00+00:00",
+                "endTime": "2024-04-02T05:00:00+00:00",
+                "isDaytime": False,
+                "temperature": 55,
+                "temperatureUnit": "F",
+                "shortForecast": "Clear",
+                "detailedForecast": "Clear with calm winds",
+                "windSpeed": "5 mph",
+                "windDirection": "NW",
+                "probabilityOfPrecipitation": {"unitCode": "wmoUnit:percent", "value": 0},
+            },
+        ],
+    }
+}
+
+
+@pytest.fixture
+def transport_factory() -> tuple[_StubTransport, dict[str, list[_StubResponse]]]:
+    responses: dict[str, list[_StubResponse]] = {}
+    transport = _StubTransport(responses)
+    return transport, responses
+
+
+def _build_client(
+    transport: _StubTransport,
+    *,
+    now_values: list[float] | None = None,
+    sleep_calls: list[float] | None = None,
+) -> NWSClient:
+    now_iter = iter(now_values or [0.0, 0.0, 0.0])
+
+    def fake_now() -> float:
+        try:
+            return next(now_iter)
+        except StopIteration:  # pragma: no cover - defensive
+            return 9999.0
+
+    sleep_log = sleep_calls if sleep_calls is not None else []
+
+    def fake_sleep(seconds: float) -> None:
+        sleep_log.append(seconds)
+
+    return NWSClient(
+        transport=transport,
+        metadata_cache_ttl=60.0,
+        forecast_cache_ttl=60.0,
+        monotonic=fake_now,
+        sleep=fake_sleep,
+    )
+
+
+def test_point_metadata_normalizes_fields_and_caches(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    url = "https://api.weather.gov/points/39.0,-77.0"
+    responses[url] = [_StubResponse(POINT_PAYLOAD)]
+
+    client = _build_client(transport, now_values=[0.0, 1.0])
+
+    result = client.point_metadata(39.0, -77.0)
+    assert result["grid_id"] == "LWX"
+    assert result["grid_x"] == 96
+    assert result["grid_y"] == 70
+    assert pytest.approx(result["distance_miles"], rel=1e-3) == 5.0
+    assert result["within_10_miles"] is True
+
+    cached = client.point_metadata(39.0, -77.0)
+    assert cached is result  # cache returns same object
+    assert transport.calls == [url]
+
+
+def test_gridpoint_forecast_normalizes_units_and_caches(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    url = "https://api.weather.gov/gridpoints/LWX/96,70/forecast"
+    responses[url] = [_StubResponse(FORECAST_PAYLOAD)]
+
+    client = _build_client(transport, now_values=[0.0, 1.0])
+    forecast = client.gridpoint_forecast("LWX", 96, 70)
+
+    assert forecast["elevation_m"] == pytest.approx(120.0)
+    assert len(forecast["periods"]) == 2
+    first_period = forecast["periods"][0]
+    assert first_period["temperature_c"] == pytest.approx(21.111, rel=1e-3)
+    assert first_period["wind_speed_mps"] == pytest.approx(3.3528, rel=1e-3)
+    assert first_period["wind_gust_mps"] == pytest.approx(8.9408, rel=1e-3)
+    assert first_period["probability_of_precipitation_pct"] == 10
+
+    # second call served from cache
+    cached = client.gridpoint_forecast("lwx", 96, 70)
+    assert cached is forecast
+    assert transport.calls == [url]
+
+
+def test_hourly_forecast_uses_distinct_cache_key(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    base = "https://api.weather.gov/gridpoints/LWX/96,70/forecast"
+    responses[base] = [_StubResponse(FORECAST_PAYLOAD)]
+    hourly_url = f"{base}/hourly"
+    responses[hourly_url] = [_StubResponse(FORECAST_PAYLOAD)]
+
+    client = _build_client(transport, now_values=[0.0, 0.0, 0.0])
+
+    _ = client.gridpoint_forecast("LWX", 96, 70, hourly=False)
+    _ = client.gridpoint_forecast("LWX", 96, 70, hourly=True)
+
+    assert transport.calls == [base, hourly_url]
+
+
+def test_backoff_respects_retry_after_header(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    url = "https://api.weather.gov/points/39.0,-77.0"
+    responses[url] = [
+        _StubResponse(POINT_PAYLOAD, status_code=429, headers={"Retry-After": "1"}),
+        _StubResponse(POINT_PAYLOAD),
+    ]
+
+    sleep_calls: list[float] = []
+    client = _build_client(transport, now_values=[0.0, 1.0, 2.0], sleep_calls=sleep_calls)
+
+    result = client.point_metadata(39.0, -77.0)
+    assert result["grid_id"] == "LWX"
+    assert sleep_calls == [1.0]
+
+
+def test_raises_error_after_retries_exhausted(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    url = "https://api.weather.gov/points/39.0,-77.0"
+    responses[url] = [
+        _StubResponse(POINT_PAYLOAD, status_code=500),
+        _StubResponse(POINT_PAYLOAD, status_code=500),
+        _StubResponse(POINT_PAYLOAD, status_code=500),
+    ]
+
+    client = _build_client(transport, now_values=[0.0, 1.0, 2.0])
+
+    with pytest.raises(NWSClientError):
+        client.point_metadata(39.0, -77.0)
+
+
+def test_cache_expires_after_ttl(transport_factory: tuple[_StubTransport, dict[str, list[_StubResponse]]]) -> None:
+    transport, responses = transport_factory
+    url = "https://api.weather.gov/gridpoints/LWX/96,70/forecast"
+    responses[url] = [_StubResponse(FORECAST_PAYLOAD), _StubResponse(FORECAST_PAYLOAD)]
+
+    client = _build_client(transport, now_values=[0.0, 10.0, 70.0])
+
+    _ = client.gridpoint_forecast("LWX", 96, 70)
+    _ = client.gridpoint_forecast("LWX", 96, 70)
+    _ = client.gridpoint_forecast("LWX", 96, 70)
+
+    assert transport.calls == [url, url]


### PR DESCRIPTION
## Summary
- add a weather package with an NWS client supporting point metadata and gridpoint forecasts with caching, retries, and unit normalization
- expose convenience functions for reuse via a shared default client
- add tests covering normalization, caching behaviour, retry/backoff handling, and TTL expiry using stubbed transports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d05d2327bc832fab7800d5e60a7bb7