### PR TITLE
AI-201: implement injuries ingestion

### DIFF
--- a/src/nfl_pred/ingest/__init__.py
+++ b/src/nfl_pred/ingest/__init__.py
@@ -7,6 +7,7 @@ from .contracts import (
     assert_team_contract,
 )
 from .pbp import ingest_pbp
+from .injuries import ingest_injuries
 from .rosters import ingest_rosters, ingest_teams
 from .schedules import ingest_schedules
 
@@ -19,4 +20,5 @@ __all__ = [
     "ingest_pbp",
     "ingest_rosters",
     "ingest_teams",
+    "ingest_injuries",
 ]

--- a/src/nfl_pred/ingest/injuries.py
+++ b/src/nfl_pred/ingest/injuries.py
@@ -1,0 +1,99 @@
+"""Injury report ingestion via ``nflreadpy``.
+
+This module mirrors the other ingestion utilities in the project by fetching
+raw data from ``nflreadpy``, attaching minimal ingestion metadata, persisting
+to Parquet, and optionally registering the output with DuckDB for
+downstream access. The injury feed includes a ``date_modified`` field which
+is surfaced as ``event_time`` to support future visibility filtering.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from pathlib import Path
+
+import nflreadpy
+import pandas as pd
+
+from nfl_pred.config import load_config
+from nfl_pred.storage.duckdb_client import DuckDBClient
+
+
+LOGGER = logging.getLogger(__name__)
+_RAW_SUBDIR = "raw"
+_INJURIES_FILENAME = "injuries.parquet"
+_DUCKDB_VIEW = "injuries_raw"
+_SOURCE_NAME = "nflreadpy"
+
+
+def ingest_injuries(seasons: list[int]) -> Path:
+    """Pull injuries for ``seasons`` and persist them to a Parquet file."""
+
+    if not seasons:
+        raise ValueError("'seasons' must contain at least one season to ingest.")
+
+    config = load_config()
+    data_dir = Path(config.paths.data_dir)
+    raw_dir = data_dir / _RAW_SUBDIR
+    raw_dir.mkdir(parents=True, exist_ok=True)
+
+    pulled_at = datetime.now(timezone.utc)
+    source_version = getattr(nflreadpy, "__version__", None)
+
+    frames: list[pd.DataFrame] = []
+    for season in seasons:
+        LOGGER.info("Loading injuries for season %s via nflreadpy", season)
+        season_df = _load_injuries(season)
+        if season_df.empty:
+            LOGGER.warning("No injury rows returned for season %s", season)
+            continue
+        frames.append(season_df)
+
+    if not frames:
+        raise RuntimeError("No injury data was retrieved for the requested seasons.")
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined["event_time"] = pd.to_datetime(
+        combined.get("date_modified"), utc=True, errors="coerce"
+    )
+    combined["pulled_at"] = pulled_at
+    combined["source"] = _SOURCE_NAME
+    combined["source_version"] = source_version
+
+    output_path = raw_dir / _INJURIES_FILENAME
+    combined.to_parquet(output_path, index=False)
+
+    LOGGER.info(
+        "Wrote injuries to %s with shape %s and columns %s",
+        output_path,
+        combined.shape,
+        list(combined.columns),
+    )
+
+    _register_with_duckdb(output_path, config.paths.duckdb_path)
+
+    return output_path
+
+
+def _load_injuries(season: int) -> pd.DataFrame:
+    """Load a single season of injury data as a pandas ``DataFrame``."""
+
+    polars_df = nflreadpy.load_injuries(season)
+    pdf = polars_df.to_pandas(use_pyarrow_extension_array=True)
+    return pdf
+
+
+def _register_with_duckdb(parquet_path: Path, duckdb_path: str) -> None:
+    """Register the Parquet file as a DuckDB view for downstream consumption."""
+
+    try:
+        with DuckDBClient(duckdb_path) as client:
+            client.register_parquet(str(parquet_path), _DUCKDB_VIEW)
+            LOGGER.info("Registered DuckDB view '%s' for %s", _DUCKDB_VIEW, parquet_path)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        LOGGER.warning("Failed to register DuckDB view '%s': %s", _DUCKDB_VIEW, exc)
+
+
+__all__ = ["ingest_injuries"]
+

--- a/tests/test_ingest_injuries.py
+++ b/tests/test_ingest_injuries.py
@@ -1,0 +1,89 @@
+"""Tests for the injuries ingestion routine."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from pandas.api.types import DatetimeTZDtype
+
+from nfl_pred.ingest.injuries import ingest_injuries
+
+
+class _DummyPolarsFrame:
+    """Minimal stub mimicking the ``to_pandas`` interface of a Polars frame."""
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self._df = df
+
+    def to_pandas(self, use_pyarrow_extension_array: bool = True) -> pd.DataFrame:  # noqa: ARG002
+        return self._df
+
+
+def test_ingest_injuries_persists_metadata(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    seasons = [2022, 2023]
+    event_times = {
+        2022: datetime(2022, 9, 1, 12, 0, tzinfo=timezone.utc),
+        2023: datetime(2023, 9, 2, 15, 30, tzinfo=timezone.utc),
+    }
+
+    def fake_load_injuries(season: int) -> _DummyPolarsFrame:
+        df = pd.DataFrame(
+            {
+                "season": [season],
+                "week": [1],
+                "team": ["KC"],
+                "date_modified": [event_times[season]],
+            }
+        )
+        return _DummyPolarsFrame(df)
+
+    # Configure paths to remain within the temporary directory.
+    data_dir = tmp_path / "data"
+    duckdb_path = tmp_path / "duck.db"
+    monkeypatch.setenv("NFLPRED__PATHS__DATA_DIR", str(data_dir))
+    monkeypatch.setenv("NFLPRED__PATHS__DUCKDB_PATH", str(duckdb_path))
+
+    # Ensure predictable source version metadata.
+    monkeypatch.setattr(
+        "nfl_pred.ingest.injuries.nflreadpy",
+        SimpleNamespace(load_injuries=fake_load_injuries, __version__="1.2.3"),
+        raising=False,
+    )
+
+    registrations: list[tuple[str, str]] = []
+    opened_db_paths: list[str] = []
+
+    class DummyDuckDBClient:
+        def __init__(self, db_path: str, read_only: bool = False) -> None:  # noqa: ARG002
+            opened_db_paths.append(db_path)
+
+        def __enter__(self) -> "DummyDuckDBClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool | None:  # noqa: ANN001, D401
+            return None
+
+        def register_parquet(self, path: str, view: str) -> None:
+            registrations.append((path, view))
+
+    monkeypatch.setattr("nfl_pred.ingest.injuries.DuckDBClient", DummyDuckDBClient)
+
+    output_path = ingest_injuries(seasons)
+
+    assert output_path == data_dir / "raw" / "injuries.parquet"
+    assert output_path.exists()
+
+    result = pd.read_parquet(output_path)
+    assert set(result["season"]) == {2022, 2023}
+    assert isinstance(result["event_time"].dtype, DatetimeTZDtype)
+    assert set(result["event_time"]) == set(event_times.values())
+    assert result["source"].eq("nflreadpy").all()
+    assert result["source_version"].eq("1.2.3").all()
+    assert isinstance(result["pulled_at"].dtype, DatetimeTZDtype)
+
+    assert registrations == [(str(output_path), "injuries_raw")]
+    assert opened_db_paths == [str(duckdb_path)]


### PR DESCRIPTION
## Summary
- add an injuries ingestion routine that persists nflreadpy data with event timestamps and metadata
- expose the new ingestion entrypoint via the ingest package initializer
- cover the ingestion flow with an offline unit test that verifies metadata and DuckDB registration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d077c518cc832fba41fa6dcd714602