### PR TITLE
AI-202: add injury practice rollups by position group

### DIFF
--- a/src/nfl_pred/features/__init__.py
+++ b/src/nfl_pred/features/__init__.py
@@ -1,5 +1,6 @@
 """Feature engineering utilities for NFL prediction models."""
 
+from .injury_rollups import build_injury_rollups
 from .stadium_join import join_stadium_metadata
 from .travel import compute_travel_features, haversine_miles
 from .weather import compute_weather_features
@@ -7,6 +8,7 @@ from .windows import RollingMetric, compute_group_rolling_windows
 
 __all__ = [
     "RollingMetric",
+    "build_injury_rollups",
     "compute_group_rolling_windows",
     "compute_travel_features",
     "compute_weather_features",

--- a/src/nfl_pred/features/injury_rollups.py
+++ b/src/nfl_pred/features/injury_rollups.py
@@ -1,0 +1,152 @@
+"""Utilities for aggregating injury report practice statuses by position group."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pandas as pd
+
+
+# Canonical mapping of roster positions to the nine position groups we expose as features.
+# The mapping intentionally covers common abbreviations for both offensive and defensive roles.
+_POSITION_TO_GROUP: Final[dict[str, str]] = {
+    # Offense
+    "QB": "QB",
+    "RB": "RB",
+    "HB": "RB",
+    "FB": "RB",
+    "WR": "WR",
+    "TE": "TE",
+    "OL": "OL",
+    "LT": "OL",
+    "RT": "OL",
+    "LG": "OL",
+    "RG": "OL",
+    "C": "OL",
+    "G": "OL",
+    "T": "OL",
+    # Defensive front
+    "DL": "DL",
+    "DE": "DL",
+    "DT": "DL",
+    "NT": "DL",
+    "EDGE": "DL",
+    # Linebackers
+    "LB": "LB",
+    "OLB": "LB",
+    "ILB": "LB",
+    "MLB": "LB",
+    # Secondary
+    "DB": "DB",
+    "CB": "DB",
+    "S": "DB",
+    "FS": "DB",
+    "SS": "DB",
+    "NB": "DB",
+    # Specialists
+    "K": "ST",
+    "P": "ST",
+    "LS": "ST",
+    "KR": "ST",
+    "PR": "ST",
+    "KOS": "ST",
+}
+
+_VALID_STATUSES: Final[frozenset[str]] = frozenset({"DNP", "LP", "FP"})
+_STATUS_NORMALIZATION: Final[dict[str, str]] = {
+    "DID NOT PRACTICE": "DNP",
+    "DID NOT PARTICIPATE": "DNP",
+    "LIMITED PARTICIPATION": "LP",
+    "LIMITED PARTICIPATION IN PRACTICE": "LP",
+    "LIMITED PRACTICE": "LP",
+    "FULL PARTICIPATION": "FP",
+    "FULL PARTICIPATION IN PRACTICE": "FP",
+    "FULL PRACTICE": "FP",
+}
+_REQUIRED_COLUMNS: Final[set[str]] = {"season", "week", "team", "position", "practice_status"}
+
+
+def _normalize_position(position: object) -> str | None:
+    """Return the canonical position group for ``position`` or ``None`` when unknown."""
+
+    if position is None:
+        return None
+    if isinstance(position, str):
+        key = position.strip().upper()
+    else:  # pragma: no cover - defensive guard for unexpected types
+        key = str(position).strip().upper()
+    return _POSITION_TO_GROUP.get(key)
+
+
+def _normalize_status(status: object) -> str | None:
+    """Normalize raw practice status strings to ``DNP``/``LP``/``FP`` codes."""
+
+    if status is None:
+        return None
+    if isinstance(status, str):
+        key = status.strip().upper()
+    else:  # pragma: no cover - defensive guard
+        key = str(status).strip().upper()
+    key = _STATUS_NORMALIZATION.get(key, key)
+    if key in _VALID_STATUSES:
+        return key
+    return None
+
+
+def build_injury_rollups(injuries: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate practice participation counts by team, week, and position group.
+
+    Parameters
+    ----------
+    injuries:
+        DataFrame containing injury report rows with at least ``season``, ``week``,
+        ``team``, ``position``, and ``practice_status`` columns.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with counts of DNP/LP/FP for each position group by team and
+        week. Entries without a recognized position group or practice status are
+        excluded, yielding zero counts for those scenarios.
+
+    Notes
+    -----
+    Rows missing either a usable position mapping or practice status code are
+    dropped rather than imputed. This keeps the resulting features faithful to
+    the available injury intelligence for the snapshot.
+    """
+
+    missing = _REQUIRED_COLUMNS.difference(injuries.columns)
+    if missing:
+        raise ValueError(f"Injuries frame is missing required columns: {sorted(missing)}")
+
+    if injuries.empty:
+        empty = pd.DataFrame(columns=["season", "week", "team", "position_group", "dnp", "lp", "fp"])
+        return empty.astype({"dnp": "int64", "lp": "int64", "fp": "int64"})
+
+    normalized = injuries.copy()
+    normalized["position_group"] = normalized["position"].map(_normalize_position)
+    normalized["status_code"] = normalized["practice_status"].map(_normalize_status)
+
+    filtered = normalized.dropna(subset=["position_group", "status_code", "season", "week", "team"])
+    if filtered.empty:
+        empty = pd.DataFrame(columns=["season", "week", "team", "position_group", "dnp", "lp", "fp"])
+        return empty.astype({"dnp": "int64", "lp": "int64", "fp": "int64"})
+
+    counts = (
+        filtered.assign(count=1)
+        .groupby(["season", "week", "team", "position_group", "status_code"], dropna=False)["count"]
+        .sum()
+        .unstack(fill_value=0)
+    )
+
+    for status in _VALID_STATUSES:
+        if status not in counts.columns:
+            counts[status] = 0
+
+    counts = counts.reset_index().rename(columns={"DNP": "dnp", "LP": "lp", "FP": "fp"})
+    counts = counts[["season", "week", "team", "position_group", "dnp", "lp", "fp"]]
+    return counts.astype({"dnp": "int64", "lp": "int64", "fp": "int64"})
+
+
+__all__ = ["build_injury_rollups"]

--- a/tests/test_injury_rollups.py
+++ b/tests/test_injury_rollups.py
@@ -1,0 +1,78 @@
+"""Tests for the injury rollup feature builder."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nfl_pred.features.injury_rollups import build_injury_rollups
+
+
+def test_build_injury_rollups_counts_practice_statuses() -> None:
+    injuries = pd.DataFrame(
+        [
+            {"season": 2023, "week": 1, "team": "KC", "position": "QB", "practice_status": "DNP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "QB", "practice_status": "Did Not Practice"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "FB", "practice_status": "Limited Participation"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "WR", "practice_status": "Full Participation"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "CB", "practice_status": "LP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "CB", "practice_status": "LP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "S", "practice_status": "DID NOT PARTICIPATE"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "LS", "practice_status": "Limited Practice"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "P", "practice_status": "FP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "K", "practice_status": "DNP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "DE", "practice_status": "DID NOT PRACTICE"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "QB", "practice_status": "Out"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "UNK", "practice_status": "DNP"},
+            {"season": 2023, "week": 1, "team": "KC", "position": "RB", "practice_status": None},
+            {"season": 2023, "week": 1, "team": "BUF", "position": "WR", "practice_status": "LP"},
+            {"season": 2023, "week": 1, "team": "BUF", "position": "WR", "practice_status": "DNP"},
+        ]
+    )
+
+    result = build_injury_rollups(injuries)
+
+    kc_qb = result[(result["team"] == "KC") & (result["position_group"] == "QB")].iloc[0]
+    assert kc_qb["dnp"] == 2
+    assert kc_qb["lp"] == 0
+    assert kc_qb["fp"] == 0
+
+    kc_rb = result[(result["team"] == "KC") & (result["position_group"] == "RB")].iloc[0]
+    assert kc_rb[["dnp", "fp"]].eq(0).all()
+    assert kc_rb["lp"] == 1
+
+    kc_db = result[(result["team"] == "KC") & (result["position_group"] == "DB")].iloc[0]
+    assert kc_db["dnp"] == 1
+    assert kc_db["lp"] == 2
+    assert kc_db["fp"] == 0
+
+    kc_st = result[(result["team"] == "KC") & (result["position_group"] == "ST")].iloc[0]
+    assert kc_st.to_dict() == {"season": 2023, "week": 1, "team": "KC", "position_group": "ST", "dnp": 1, "lp": 1, "fp": 1}
+
+    kc_dl = result[(result["team"] == "KC") & (result["position_group"] == "DL")].iloc[0]
+    assert kc_dl["dnp"] == 1
+    assert kc_dl["lp"] == 0
+    assert kc_dl["fp"] == 0
+
+    kc_wr = result[(result["team"] == "KC") & (result["position_group"] == "WR")].iloc[0]
+    assert kc_wr["fp"] == 1
+    assert kc_wr[["dnp", "lp"]].eq(0).all()
+
+    buf_wr = result[(result["team"] == "BUF") & (result["position_group"] == "WR")].iloc[0]
+    assert buf_wr.to_dict() == {"season": 2023, "week": 1, "team": "BUF", "position_group": "WR", "dnp": 1, "lp": 1, "fp": 0}
+
+    assert set(result["position_group"]) == {"QB", "RB", "WR", "DB", "ST", "DL"}
+
+
+def test_build_injury_rollups_handles_empty_frame() -> None:
+    injuries = pd.DataFrame(columns=["season", "week", "team", "position", "practice_status"])
+
+    result = build_injury_rollups(injuries)
+
+    assert result.empty
+    assert list(result.columns) == ["season", "week", "team", "position_group", "dnp", "lp", "fp"]
+
+
+def test_build_injury_rollups_missing_columns() -> None:
+    with pytest.raises(ValueError):
+        build_injury_rollups(pd.DataFrame({"season": [2023]}))


### PR DESCRIPTION
## Summary
- implement position-to-group and status normalization helpers to aggregate injury practice participation counts
- expose a `build_injury_rollups` feature utility and corresponding unit tests covering normalization and edge cases

## Testing
- `PYTHONPATH=src pytest tests/test_injury_rollups.py`


------
https://chatgpt.com/codex/tasks/task_e_68d078d890bc832f962900b886dd655d