### PR TITLE
AI-204: enforce snapshot visibility filters

### DIFF
--- a/src/nfl_pred/features/team_week.py
+++ b/src/nfl_pred/features/team_week.py
@@ -60,6 +60,7 @@ import numpy as np
 import pandas as pd
 
 from nfl_pred.features.windows import RollingMetric, compute_group_rolling_windows
+from nfl_pred.snapshot.visibility import VisibilityContext, filter_play_by_play
 
 TEAM_WEEK_WINDOW_LENGTHS: Final[dict[str, int | None]] = {"w4": 4, "w8": 8, "season": None}
 
@@ -95,9 +96,8 @@ def _safe_divide(numerator: pd.Series, denominator: pd.Series) -> pd.Series:
 
 
 def _prepare_source_frame(pbp: pd.DataFrame, *, asof_ts: pd.Timestamp | None) -> pd.DataFrame:
-    working = pbp.copy()
-    if asof_ts is not None and "asof_ts" in working.columns:
-        working = working.loc[working["asof_ts"] <= asof_ts].copy()
+    context = VisibilityContext(asof_ts=asof_ts)
+    working = filter_play_by_play(pbp, context=context)
 
     _ensure_required_columns(working)
 

--- a/src/nfl_pred/snapshot/__init__.py
+++ b/src/nfl_pred/snapshot/__init__.py
@@ -1,12 +1,7 @@
 """Snapshot orchestration utilities for the NFL prediction pipeline."""
 
-from .runner import (
-    DEFAULT_SNAPSHOT_STAGES,
-    SnapshotRunner,
-    SnapshotStage,
-    StageExecution,
-    run_snapshot_workflow,
-)
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "DEFAULT_SNAPSHOT_STAGES",
@@ -15,3 +10,10 @@ __all__ = [
     "StageExecution",
     "run_snapshot_workflow",
 ]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin re-export shim
+    if name in __all__:
+        module = import_module("nfl_pred.snapshot.runner")
+        return getattr(module, name)
+    raise AttributeError(f"module 'nfl_pred.snapshot' has no attribute {name!r}")

--- a/src/nfl_pred/snapshot/visibility.py
+++ b/src/nfl_pred/snapshot/visibility.py
@@ -1,0 +1,160 @@
+"""Snapshot visibility utilities for feature builders.
+
+The helpers defined here centralise the enforcement of ``asof_ts`` cut-offs
+across the various feature builders. Each function accepts a pandas
+``DataFrame`` and returns a filtered copy where events occurring strictly after
+``asof_ts`` have been removed. When precise event timestamps are unavailable the
+helpers degrade gracefully by falling back to coarser season/week filters so we
+avoid introducing silent leakage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+
+__all__ = [
+    "VisibilityContext",
+    "filter_play_by_play",
+    "filter_schedule",
+    "filter_weekly_frame",
+]
+
+
+@dataclass(frozen=True)
+class VisibilityContext:
+    """Container describing the snapshot cut-off for a build."""
+
+    season: int | None = None
+    week: int | None = None
+    asof_ts: pd.Timestamp | None = None
+
+
+def filter_play_by_play(
+    pbp: pd.DataFrame,
+    *,
+    context: VisibilityContext,
+    event_time_col: str = "event_time",
+    ingestion_time_col: str = "asof_ts",
+) -> pd.DataFrame:
+    """Return play-by-play rows visible at ``context.asof_ts``.
+
+    The function first enforces a hard cut on ``event_time_col``. Rows with a
+    valid event timestamp strictly greater than ``asof_ts`` are dropped even if
+    ingestion timestamps indicate earlier availability. For rows lacking precise
+    event timestamps we fall back to ``ingestion_time_col`` when present. If
+    neither timestamp exists we further degrade to season/week filtering when
+    the context provides those values.
+    """
+
+    if pbp.empty:
+        return pbp.copy()
+
+    working = pbp.copy()
+    cutoff = _ensure_optional_cutoff(context.asof_ts)
+
+    mask = pd.Series(True, index=working.index, dtype=bool)
+    fallback_candidates = pd.Series(True, index=working.index, dtype=bool)
+
+    if cutoff is not None and event_time_col in working.columns:
+        event_times = pd.to_datetime(working[event_time_col], utc=True, errors="coerce")
+        event_known = event_times.notna()
+        mask &= (~event_known) | (event_times <= cutoff)
+        fallback_candidates = fallback_candidates & (~event_known)
+
+    if cutoff is not None and ingestion_time_col in working.columns:
+        ingestion_times = pd.to_datetime(working[ingestion_time_col], utc=True, errors="coerce")
+        ingestion_known = ingestion_times.notna()
+        mask &= (~fallback_candidates) | (~ingestion_known) | (ingestion_times <= cutoff)
+        fallback_candidates = fallback_candidates & (~ingestion_known)
+
+    if cutoff is not None:
+        working = working.loc[mask].copy()
+
+    if context.season is not None and context.week is not None:
+        working = filter_weekly_frame(
+            working,
+            season=context.season,
+            week=context.week,
+            season_column="season",
+            week_column="week",
+        )
+
+    return working
+
+
+def filter_schedule(
+    schedule: pd.DataFrame,
+    *,
+    context: VisibilityContext,
+    kickoff_column: str = "start_time",
+) -> pd.DataFrame:
+    """Return schedule rows visible at ``context.asof_ts``."""
+
+    if schedule.empty:
+        return schedule.copy()
+
+    working = schedule.copy()
+    cutoff = _ensure_optional_cutoff(context.asof_ts)
+
+    if kickoff_column in working.columns and cutoff is not None:
+        kickoff = pd.to_datetime(working[kickoff_column], utc=True, errors="coerce")
+        mask = kickoff.isna() | (kickoff <= cutoff)
+        working = working.loc[mask].copy()
+
+    if context.season is not None and context.week is not None:
+        working = filter_weekly_frame(
+            working,
+            season=context.season,
+            week=context.week,
+            season_column="season",
+            week_column="week",
+        )
+
+    return working
+
+
+def filter_weekly_frame(
+    df: pd.DataFrame,
+    *,
+    season: int,
+    week: int,
+    season_column: str = "season",
+    week_column: str = "week",
+    columns_required: Iterable[str] | None = None,
+) -> pd.DataFrame:
+    """Restrict a frame to rows with ``season/week`` up to the target week."""
+
+    if df.empty:
+        return df.copy()
+
+    if columns_required is not None:
+        missing = sorted(set(columns_required) - set(df.columns))
+        if missing:
+            raise KeyError(f"Dataframe missing required columns for visibility filtering: {missing}")
+
+    if season_column not in df.columns or week_column not in df.columns:
+        raise KeyError("Dataframe must contain season/week columns for fallback visibility filtering.")
+
+    filtered = df.copy()
+    filtered[season_column] = filtered[season_column].astype(int)
+    filtered[week_column] = filtered[week_column].astype(int)
+
+    mask = (filtered[season_column] < season) | (
+        (filtered[season_column] == season) & (filtered[week_column] <= week)
+    )
+
+    return filtered.loc[mask].copy()
+
+
+def _ensure_optional_cutoff(value: pd.Timestamp | str | None) -> pd.Timestamp | None:
+    if value is None:
+        return None
+
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize("UTC")
+    return timestamp.tz_convert("UTC")

--- a/tests/test_schedule_meta.py
+++ b/tests/test_schedule_meta.py
@@ -116,3 +116,13 @@ def test_compute_schedule_meta_kickoff_buckets_and_site() -> None:
 
     away = meta.loc[(meta["game_id"] == "2023_04_JAX_HOU") & (meta["team"] == "HOU")]
     assert away["home_away"].iloc[0] == "away"
+
+
+def test_compute_schedule_meta_respects_asof_cutoff() -> None:
+    schedule = _schedule_frame()
+
+    cutoff = pd.Timestamp("2023-09-18T00:00:00Z")
+    meta = compute_schedule_meta(schedule, asof_ts=cutoff)
+
+    assert meta["week"].max() == 2
+    assert set(meta["game_id"]) <= {"2023_01_NE_MIA", "2023_01_DAL_NYG", "2023_01_NO_CAR", "2023_02_PHI_NE", "2023_02_MIA_DEN"}

--- a/tests/test_snapshot_visibility.py
+++ b/tests/test_snapshot_visibility.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nfl_pred.snapshot.visibility import (
+    VisibilityContext,
+    filter_play_by_play,
+    filter_schedule,
+    filter_weekly_frame,
+)
+
+
+def test_filter_play_by_play_enforces_event_time_cutoff() -> None:
+    context = VisibilityContext(asof_ts=pd.Timestamp("2023-09-15T00:00:00Z"))
+    pbp = pd.DataFrame(
+        {
+            "season": [2023, 2023, 2023, 2023],
+            "week": [1, 2, 2, 3],
+            "event_time": [
+                "2023-09-10T17:00:00Z",
+                "2023-09-14T23:00:00Z",
+                pd.NaT,
+                pd.NaT,
+            ],
+            "asof_ts": [
+                "2023-09-10T20:00:00Z",
+                "2023-09-14T23:30:00Z",
+                "2023-09-14T12:00:00Z",
+                "2023-09-17T12:00:00Z",
+            ],
+            "value": [1, 2, 3, 4],
+        }
+    )
+
+    filtered = filter_play_by_play(pbp, context=context)
+
+    assert filtered["value"].tolist() == [1, 2, 3]
+    assert 4 not in filtered["value"].tolist()
+
+
+def test_filter_schedule_applies_asof_and_week() -> None:
+    schedule = pd.DataFrame(
+        {
+            "season": [2023, 2023, 2023],
+            "week": [1, 2, 3],
+            "start_time": [
+                "2023-09-10T17:00:00Z",
+                "2023-09-17T20:25:00Z",
+                "2023-09-24T20:20:00Z",
+            ],
+            "game_id": ["g1", "g2", "g3"],
+        }
+    )
+
+    context = VisibilityContext(season=2023, week=2, asof_ts=pd.Timestamp("2023-09-19T00:00:00Z"))
+    filtered = filter_schedule(schedule, context=context)
+
+    assert filtered["game_id"].tolist() == ["g1", "g2"]
+
+
+def test_filter_weekly_frame_requires_columns() -> None:
+    df = pd.DataFrame({"season": [2023], "value": [1]})
+
+    with pytest.raises(KeyError):
+        filter_weekly_frame(df, season=2023, week=1)

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -133,3 +133,12 @@ def test_compute_travel_features_missing_coordinates(sample_schedule: pd.DataFra
 
     london_rows = features[features["game_id"] == "2023_03_nyj_mia"]
     assert london_rows["travel_miles"].isna().all()
+
+
+def test_compute_travel_features_respects_asof_cutoff(sample_schedule: pd.DataFrame) -> None:
+    cutoff = pd.Timestamp("2023-09-18T00:00:00Z")
+
+    features = compute_travel_features(sample_schedule, asof_ts=cutoff)
+
+    assert features["week"].max() == 2
+    assert set(features["game_id"]) <= {"2023_01_buf_nyj", "2023_02_nyj_dal"}


### PR DESCRIPTION
## Summary
- add snapshot visibility helpers centralizing as-of filtering for play-by-play and schedule inputs
- wire feature builders to pass through the new visibility context and expose asof_ts parameters for schedule and travel features
- extend snapshot and feature tests to cover event-time filtering and schedule/travel cut-offs while avoiding circular imports via lazy exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d07f4b3ca0832fa3afda55b2ab3162