### PR TITLE
Add stacking ensemble pipeline (AI-302)

### DIFF
--- a/src/nfl_pred/model/__init__.py
+++ b/src/nfl_pred/model/__init__.py
@@ -9,6 +9,7 @@ from .models import (  # noqa: F401
     RidgeModel,
 )
 from .splits import time_series_splits  # noqa: F401
+from .stacking import StackingEnsemble, generate_out_of_fold_predictions  # noqa: F401
 
 __all__ = [
     "BaselineClassifier",
@@ -18,4 +19,6 @@ __all__ = [
     "RidgeModel",
     "GradientBoostingModel",
     "MODEL_PARAM_GRIDS",
+    "StackingEnsemble",
+    "generate_out_of_fold_predictions",
 ]

--- a/src/nfl_pred/model/stacking.py
+++ b/src/nfl_pred/model/stacking.py
@@ -1,0 +1,197 @@
+"""Stacking ensemble utilities for combining level-0 models."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+
+ArrayLike = pd.DataFrame | np.ndarray
+ModelFactory = Callable[[], "SupportsPredictProba"]
+
+
+class SupportsPredictProba:
+    """Protocol-like base to satisfy type checkers for model factories."""
+
+    def fit(self, X: ArrayLike, y: Sequence[int | float]) -> "SupportsPredictProba":  # pragma: no cover - interface shim
+        raise NotImplementedError
+
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:  # pragma: no cover - interface shim
+        raise NotImplementedError
+
+
+def _ensure_2d(X: ArrayLike) -> np.ndarray:
+    if isinstance(X, pd.DataFrame):
+        values = X.to_numpy(copy=True)
+    else:
+        values = np.asarray(X)
+
+    if values.ndim != 2:
+        raise ValueError("Feature matrix must be two-dimensional.")
+    return values
+
+
+def _ensure_1d(y: Sequence[int | float]) -> np.ndarray:
+    values = np.asarray(list(y), dtype=float)
+    if values.ndim != 1:
+        values = values.ravel()
+
+    if np.unique(values).size < 2:
+        raise ValueError("Target vector must contain at least two classes.")
+    return values
+
+
+def _slice_rows(X: ArrayLike, indices: np.ndarray) -> ArrayLike:
+    if isinstance(X, pd.DataFrame):
+        return X.iloc[indices]
+    return X[indices]
+
+
+def _positive_column(proba: np.ndarray) -> np.ndarray:
+    if proba.ndim != 2 or proba.shape[1] < 2:
+        raise ValueError("Predicted probabilities must have shape (n_samples, 2).")
+    return proba[:, 1]
+
+
+def generate_out_of_fold_predictions(
+    base_model_factories: Mapping[str, ModelFactory],
+    X: ArrayLike,
+    y: Sequence[int | float],
+    cv_splits: Iterable[tuple[np.ndarray, np.ndarray]],
+) -> pd.DataFrame:
+    """Return a DataFrame of out-of-fold probabilities for each base model."""
+
+    if not base_model_factories:
+        raise ValueError("At least one base model factory is required for stacking.")
+
+    splits = list(cv_splits)
+    if not splits:
+        raise ValueError("No cross-validation splits were provided.")
+
+    X_values = _ensure_2d(X)
+    y_array = _ensure_1d(y)
+    if X_values.shape[0] != y_array.shape[0]:
+        raise ValueError("Features and target must contain the same number of rows.")
+
+    index = X.index if isinstance(X, pd.DataFrame) else pd.RangeIndex(len(X_values))
+    model_names = list(base_model_factories.keys())
+    oof = np.full((len(index), len(model_names)), np.nan, dtype=float)
+
+    for train_idx, val_idx in splits:
+        if len(val_idx) == 0:
+            raise ValueError("Validation fold contains no rows.")
+
+        X_train = _slice_rows(X, train_idx)
+        y_train = y_array[train_idx]
+        X_val = _slice_rows(X, val_idx)
+
+        for model_position, (name, factory) in enumerate(base_model_factories.items()):
+            model = factory()
+            fitted = model.fit(X_train, y_train)
+            if fitted is not model:
+                model = fitted
+
+            proba = model.predict_proba(X_val)
+            oof[val_idx, model_position] = _positive_column(proba)
+
+    return pd.DataFrame(oof, index=index, columns=model_names)
+
+
+@dataclass
+class StackingEnsemble:
+    """Stack multiple level-0 models with a logistic meta-learner."""
+
+    base_model_factories: Mapping[str, ModelFactory]
+    meta_solver: str = "lbfgs"
+    meta_max_iter: int = 500
+    random_state: int | None = 42
+
+    def __post_init__(self) -> None:
+        if not self.base_model_factories:
+            raise ValueError("StackingEnsemble requires at least one base model factory.")
+        self._base_model_factories: "OrderedDict[str, ModelFactory]" = OrderedDict(
+            self.base_model_factories
+        )
+        self._meta_model: LogisticRegression | None = None
+        self._fitted_base_models: MutableMapping[str, SupportsPredictProba] | None = None
+        self._oof_predictions: pd.DataFrame | None = None
+
+    @property
+    def base_model_names(self) -> list[str]:
+        return list(self._base_model_factories.keys())
+
+    @property
+    def oof_predictions_(self) -> pd.DataFrame:
+        if self._oof_predictions is None:
+            raise RuntimeError("StackingEnsemble has not been fitted yet.")
+        return self._oof_predictions
+
+    @property
+    def meta_model_(self) -> LogisticRegression:
+        if self._meta_model is None:
+            raise RuntimeError("StackingEnsemble has not been fitted yet.")
+        return self._meta_model
+
+    @property
+    def base_models_(self) -> Mapping[str, SupportsPredictProba]:
+        if self._fitted_base_models is None:
+            raise RuntimeError("StackingEnsemble has not been fitted yet.")
+        return self._fitted_base_models
+
+    def fit(
+        self,
+        X: ArrayLike,
+        y: Sequence[int | float],
+        cv_splits: Iterable[tuple[np.ndarray, np.ndarray]],
+    ) -> "StackingEnsemble":
+        oof = generate_out_of_fold_predictions(self._base_model_factories, X, y, cv_splits)
+
+        y_array = _ensure_1d(y)
+
+        oof_matrix = oof.to_numpy()
+        valid_mask = ~np.isnan(oof_matrix).any(axis=1)
+        if not np.any(valid_mask):
+            raise RuntimeError("No validation rows were scored for stacking.")
+
+        meta_model = LogisticRegression(
+            solver=self.meta_solver,
+            max_iter=self.meta_max_iter,
+            random_state=self.random_state,
+        )
+        meta_model.fit(oof_matrix[valid_mask], y_array[valid_mask])
+
+        fitted_base_models: OrderedDict[str, SupportsPredictProba] = OrderedDict()
+        for name, factory in self._base_model_factories.items():
+            model = factory()
+            fitted = model.fit(X, y)
+            fitted_base_models[name] = fitted if fitted is not None else model
+
+        self._meta_model = meta_model
+        self._fitted_base_models = fitted_base_models
+        self._oof_predictions = oof
+        return self
+
+    def predict_meta_features(self, X: ArrayLike) -> np.ndarray:
+        if self._fitted_base_models is None:
+            raise RuntimeError("StackingEnsemble must be fitted before prediction.")
+
+        features = []
+        for name in self.base_model_names:
+            model = self._fitted_base_models[name]
+            proba = model.predict_proba(X)
+            features.append(_positive_column(proba))
+
+        return np.column_stack(features)
+
+    def predict_proba(self, X: ArrayLike) -> np.ndarray:
+        meta_features = self.predict_meta_features(X)
+        meta_model = self.meta_model_
+        return meta_model.predict_proba(meta_features)
+
+    def predict(self, X: ArrayLike) -> np.ndarray:
+        return (self.predict_proba(X)[:, 1] >= 0.5).astype(int)

--- a/tests/test_model_stacking.py
+++ b/tests/test_model_stacking.py
@@ -1,0 +1,115 @@
+"""Tests for the stacking ensemble utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.metrics import log_loss
+
+from nfl_pred.model.splits import time_series_splits
+from nfl_pred.model.stacking import (
+    StackingEnsemble,
+    generate_out_of_fold_predictions,
+)
+
+
+class _BiasedSigmoidModel:
+    def __init__(self, column: str, bias: float) -> None:
+        self.column = column
+        self.bias = bias
+        self._mean: float | None = None
+        self._std: float | None = None
+
+    def fit(self, X: pd.DataFrame, y: np.ndarray) -> "_BiasedSigmoidModel":
+        series = X[self.column]
+        self._mean = float(series.mean())
+        self._std = float(series.std() or 1.0)
+        return self
+
+    def predict_proba(self, X: pd.DataFrame) -> np.ndarray:
+        if self._mean is None or self._std is None:
+            raise RuntimeError("Model must be fitted before prediction.")
+        normalized = (X[self.column] - self._mean) / self._std
+        positive = 1.0 / (1.0 + np.exp(-normalized)) + self.bias
+        clipped = np.clip(positive, 1e-4, 1 - 1e-4)
+        return np.column_stack([1.0 - clipped, clipped])
+
+
+@pytest.fixture()
+def toy_stack_dataset() -> tuple[pd.DataFrame, np.ndarray]:
+    rng = np.random.default_rng(42)
+    weeks = np.repeat(np.arange(1, 7), 30)
+    feature_1 = rng.normal(size=weeks.size)
+    feature_2 = rng.normal(size=weeks.size)
+    logits = 1.1 * feature_1 + 1.1 * feature_2
+    probabilities = 1.0 / (1.0 + np.exp(-logits))
+    outcomes = rng.binomial(1, probabilities)
+
+    df = pd.DataFrame(
+        {
+            "week": weeks,
+            "feature_1": feature_1,
+            "feature_2": feature_2,
+        }
+    )
+    return df, outcomes
+
+
+def test_generate_out_of_fold_predictions_shape(toy_stack_dataset: tuple[pd.DataFrame, np.ndarray]) -> None:
+    df, y = toy_stack_dataset
+    features = df[["feature_1", "feature_2"]]
+    splits = list(time_series_splits(df, group_col="week", min_train_weeks=2))
+
+    oof = generate_out_of_fold_predictions(
+        {
+            "biased_1": lambda: _BiasedSigmoidModel("feature_1", 0.15),
+            "biased_2": lambda: _BiasedSigmoidModel("feature_2", -0.08),
+        },
+        features,
+        y,
+        splits,
+    )
+
+    assert oof.shape == (features.shape[0], 2)
+    assert list(oof.columns) == ["biased_1", "biased_2"]
+
+    late_weeks = df["week"] >= 3
+    late_predictions = oof.loc[late_weeks]
+    assert np.all((0.0 <= late_predictions.to_numpy()) & (late_predictions.to_numpy() <= 1.0))
+    assert late_predictions.notna().all().all()
+    assert oof.loc[~late_weeks].isna().any(axis=1).all()
+
+
+def test_stacking_meta_outperforms_best_base_on_holdout(
+    toy_stack_dataset: tuple[pd.DataFrame, np.ndarray]
+) -> None:
+    df, y = toy_stack_dataset
+    features = df[["feature_1", "feature_2"]]
+    train_mask = df["week"] <= 5
+    test_mask = ~train_mask
+
+    X_train = features.loc[train_mask]
+    y_train = y[train_mask.to_numpy()]
+    X_test = features.loc[test_mask]
+    y_test = y[test_mask.to_numpy()]
+
+    factories = {
+        "biased_1": lambda: _BiasedSigmoidModel("feature_1", 0.15),
+        "biased_2": lambda: _BiasedSigmoidModel("feature_2", -0.08),
+    }
+
+    splits = list(time_series_splits(df.loc[train_mask], group_col="week", min_train_weeks=2))
+
+    ensemble = StackingEnsemble(factories, meta_max_iter=600)
+    ensemble.fit(X_train, y_train, splits)
+
+    meta_proba = ensemble.predict_proba(X_test)[:, 1]
+    base_losses = []
+    for model in ensemble.base_models_.values():
+        base_prob = model.predict_proba(X_test)[:, 1]
+        base_losses.append(log_loss(y_test, base_prob, labels=[0, 1]))
+
+    meta_loss = log_loss(y_test, meta_proba, labels=[0, 1])
+
+    assert meta_loss < min(base_losses)


### PR DESCRIPTION
## Summary
- implement stacking ensemble utilities with logistic meta-learner and reusable out-of-fold generator
- expose the stacking helpers through the public model package for downstream pipelines
- add tests covering OOF matrix construction and ensuring the stacked model beats the base learners on a holdout split

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0885423d0832fa2d432e550730822