### PR TITLE
AI-303: add calibration selection utilities

### DIFF
--- a/src/nfl_pred/model/calibration.py
+++ b/src/nfl_pred/model/calibration.py
@@ -1,12 +1,14 @@
-"""Platt scaling calibration utilities."""
+"""Probability calibration utilities for binary classifiers."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any, Callable, Dict, Iterable, Mapping, Protocol, Sequence
 
 import numpy as np
+from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import brier_score_loss, log_loss
 
 
 def _as_1d_array(values: Iterable[Any]) -> np.ndarray:
@@ -147,3 +149,269 @@ class PlattCalibrator:
     def _ensure_fitted(self) -> None:
         if self._params is None or self._base_model is None or self._positive_index is None:
             raise RuntimeError("PlattCalibrator must be fitted before use.")
+
+
+class IsotonicCalibrator:
+    """Calibrate probabilities using isotonic regression."""
+
+    def __init__(
+        self,
+        *,
+        y_min: float = 0.0,
+        y_max: float = 1.0,
+        out_of_bounds: str = "clip",
+    ) -> None:
+        self.y_min = y_min
+        self.y_max = y_max
+        self.out_of_bounds = out_of_bounds
+
+        self._base_model: Any | None = None
+        self._regressor: IsotonicRegression | None = None
+        self._classes: np.ndarray | None = None
+        self._positive_index: int | None = None
+
+    def fit(
+        self,
+        base_model: Any,
+        X_valid: Any,
+        y_valid: Iterable[Any],
+    ) -> "IsotonicCalibrator":
+        """Fit the isotonic calibrator using validation data."""
+
+        if not hasattr(base_model, "predict_proba"):
+            raise TypeError("base_model must implement predict_proba().")
+
+        probs = np.asarray(base_model.predict_proba(X_valid))
+        if probs.ndim != 2 or probs.shape[1] != 2:
+            raise ValueError("IsotonicCalibrator requires binary probabilities with two columns.")
+
+        if hasattr(base_model, "classes_"):
+            classes = np.asarray(base_model.classes_)
+            if classes.shape[0] != 2:
+                raise ValueError("IsotonicCalibrator only supports binary classifiers.")
+        else:
+            classes = np.array([0, 1])
+
+        if 1 in classes:
+            positive_index = int(np.where(classes == 1)[0][0])
+        else:
+            positive_index = 1
+
+        y_array = _as_1d_array(y_valid)
+        if y_array.size != probs.shape[0]:
+            raise ValueError("X_valid and y_valid must contain the same number of rows.")
+
+        regressor = IsotonicRegression(
+            y_min=self.y_min,
+            y_max=self.y_max,
+            out_of_bounds=self.out_of_bounds,
+        )
+        regressor.fit(probs[:, positive_index], y_array)
+
+        self._base_model = base_model
+        self._regressor = regressor
+        self._classes = classes
+        self._positive_index = positive_index
+        return self
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        """Return calibrated probabilities for ``X``."""
+
+        self._ensure_fitted()
+        assert self._base_model is not None
+        assert self._regressor is not None
+        assert self._positive_index is not None
+
+        base_probs = np.asarray(self._base_model.predict_proba(X))
+        if base_probs.ndim != 2 or base_probs.shape[1] != 2:
+            raise ValueError("IsotonicCalibrator requires binary probabilities with two columns.")
+
+        positive_probs = base_probs[:, self._positive_index]
+        calibrated_positive = self._regressor.transform(positive_probs)
+        calibrated = base_probs.copy()
+        calibrated[:, self._positive_index] = calibrated_positive
+        calibrated[:, 1 - self._positive_index] = 1 - calibrated_positive
+        return calibrated
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Predict class labels using calibrated probabilities."""
+
+        probs = self.predict_proba(X)
+        return (probs[:, self._positive_index] >= 0.5).astype(int)
+
+    @property
+    def classes_(self) -> np.ndarray:
+        """Return the class ordering used by the calibrator."""
+
+        self._ensure_fitted()
+        assert self._classes is not None
+        return self._classes
+
+    def _ensure_fitted(self) -> None:
+        if self._regressor is None or self._base_model is None or self._positive_index is None:
+            raise RuntimeError("IsotonicCalibrator must be fitted before use.")
+
+
+class _CalibratorProtocol(Protocol):
+    """Protocol describing the calibrator interface used for selection."""
+
+    def fit(self, base_model: Any, X_valid: Any, y_valid: Iterable[Any]) -> "_CalibratorProtocol":
+        ...
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        ...
+
+    @property
+    def classes_(self) -> np.ndarray:
+        ...
+
+
+def _default_calibrator_factories() -> Sequence[tuple[str, Callable[[], _CalibratorProtocol]]]:
+    return (
+        ("platt", PlattCalibrator),
+        ("isotonic", IsotonicCalibrator),
+    )
+
+
+def _compute_metric(
+    *,
+    metric: str,
+    y_true: np.ndarray,
+    probs: np.ndarray,
+    classes: np.ndarray,
+) -> float:
+    if metric == "log_loss":
+        return float(log_loss(y_true, probs, labels=classes))
+    if metric == "brier":
+        if 1 in classes:
+            positive_index = int(np.where(classes == 1)[0][0])
+        else:
+            positive_index = 1
+        return float(brier_score_loss(y_true, probs[:, positive_index]))
+    raise ValueError("metric must be 'log_loss' or 'brier'.")
+
+
+def compare_calibrators(
+    base_model: Any,
+    X_valid: Any,
+    y_valid: Iterable[Any],
+    *,
+    metric: str = "log_loss",
+    minimum_isotonic_samples: int = 75,
+    calibrator_factories: Sequence[tuple[str, Callable[[], _CalibratorProtocol]]] | None = None,
+) -> tuple[str, Dict[str, float], Dict[str, _CalibratorProtocol]]:
+    """Fit and evaluate multiple calibrators, returning the best performer."""
+
+    y_array = _as_1d_array(y_valid)
+    if y_array.size == 0:
+        raise ValueError("y_valid must contain at least one sample.")
+    unique = np.unique(y_array)
+    if unique.shape[0] != 2:
+        raise ValueError("Calibration comparison requires both classes in y_valid.")
+
+    factories = calibrator_factories or _default_calibrator_factories()
+
+    metrics: Dict[str, float] = {}
+    fitted: Dict[str, _CalibratorProtocol] = {}
+    best_name: str | None = None
+    best_metric = float("inf")
+
+    for name, factory in factories:
+        if name == "isotonic" and y_array.size < minimum_isotonic_samples:
+            continue
+
+        calibrator = factory()
+        fitted_calibrator = calibrator.fit(base_model, X_valid, y_array)
+        probs = np.asarray(fitted_calibrator.predict_proba(X_valid))
+        metric_value = _compute_metric(
+            metric=metric,
+            y_true=y_array,
+            probs=probs,
+            classes=fitted_calibrator.classes_,
+        )
+        metrics[name] = metric_value
+        fitted[name] = fitted_calibrator
+        if metric_value < best_metric:
+            best_metric = metric_value
+            best_name = name
+
+    if not metrics:
+        raise ValueError("No calibrators were evaluated; check sample sizes and configuration.")
+
+    assert best_name is not None
+    return best_name, metrics, fitted
+
+
+class CalibrationSelector:
+    """Select the best calibrator based on validation performance."""
+
+    def __init__(
+        self,
+        *,
+        metric: str = "log_loss",
+        minimum_isotonic_samples: int = 75,
+        calibrator_factories: Sequence[tuple[str, Callable[[], _CalibratorProtocol]]] | None = None,
+    ) -> None:
+        self.metric = metric
+        self.minimum_isotonic_samples = minimum_isotonic_samples
+        self.calibrator_factories = calibrator_factories
+
+        self._selected_name: str | None = None
+        self._selected_calibrator: _CalibratorProtocol | None = None
+        self._metrics: Dict[str, float] | None = None
+
+    def fit(self, base_model: Any, X_valid: Any, y_valid: Iterable[Any]) -> "CalibrationSelector":
+        """Fit available calibrators and retain the best performer."""
+
+        best_name, metrics, fitted = compare_calibrators(
+            base_model,
+            X_valid,
+            y_valid,
+            metric=self.metric,
+            minimum_isotonic_samples=self.minimum_isotonic_samples,
+            calibrator_factories=self.calibrator_factories,
+        )
+
+        self._selected_name = best_name
+        self._selected_calibrator = fitted[best_name]
+        self._metrics = metrics
+        return self
+
+    def predict_proba(self, X: Any) -> np.ndarray:
+        """Predict calibrated probabilities using the selected calibrator."""
+
+        calibrator = self._ensure_selected()
+        return calibrator.predict_proba(X)
+
+    def predict(self, X: Any) -> np.ndarray:
+        """Predict class labels using the selected calibrator."""
+
+        calibrator = self._ensure_selected()
+        return calibrator.predict(X)
+
+    @property
+    def selected_calibrator_name(self) -> str:
+        """Name of the chosen calibrator."""
+
+        self._ensure_selected()
+        assert self._selected_name is not None
+        return self._selected_name
+
+    @property
+    def metrics_(self) -> Mapping[str, float]:
+        """Validation metric values for each evaluated calibrator."""
+
+        self._ensure_selected()
+        assert self._metrics is not None
+        return self._metrics
+
+    @property
+    def calibrator_(self) -> _CalibratorProtocol:
+        """Return the fitted calibrator selected during ``fit``."""
+
+        return self._ensure_selected()
+
+    def _ensure_selected(self) -> _CalibratorProtocol:
+        if self._selected_calibrator is None:
+            raise RuntimeError("CalibrationSelector must be fitted before use.")
+        return self._selected_calibrator

--- a/tests/test_calibration_selection.py
+++ b/tests/test_calibration_selection.py
@@ -1,0 +1,86 @@
+"""Tests for calibration selection utilities (AI-303)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from nfl_pred.model.calibration import CalibrationSelector, compare_calibrators
+
+
+class DummyModel:
+    """Simple model returning predetermined probabilities based on ``X``."""
+
+    def __init__(self, transform) -> None:
+        self._transform = transform
+        self.classes_ = np.array([0, 1])
+
+    def predict_proba(self, X):
+        x = np.asarray(X).reshape(-1)
+        positive = np.clip(self._transform(x), 1e-6, 1 - 1e-6)
+        return np.column_stack([1 - positive, positive])
+
+
+def _generate_nonlinear_dataset(num_points: int = 30, samples_per_point: int = 40):
+    x_grid = np.linspace(0.05, 0.95, num_points)
+    true_probs = x_grid**2
+
+    X_valid = np.repeat(x_grid, samples_per_point).reshape(-1, 1)
+    y_valid = []
+    for prob in true_probs:
+        positives = int(round(prob * samples_per_point))
+        positives = min(max(positives, 0), samples_per_point)
+        y_valid.extend([1] * positives)
+        y_valid.extend([0] * (samples_per_point - positives))
+
+    return X_valid, np.asarray(y_valid)
+
+
+def test_compare_calibrators_prefers_isotonic_for_nonlinear_relationship():
+    base_model = DummyModel(lambda x: x)
+    X_valid, y_valid = _generate_nonlinear_dataset()
+
+    best_name, metrics, _ = compare_calibrators(
+        base_model,
+        X_valid,
+        y_valid,
+        metric="brier",
+        minimum_isotonic_samples=50,
+    )
+
+    assert best_name == "isotonic"
+    assert "isotonic" in metrics
+    assert "platt" in metrics
+    assert metrics["isotonic"] < metrics["platt"]
+
+
+def test_compare_calibrators_skips_isotonic_when_sample_small():
+    base_model = DummyModel(lambda x: 0.25 + 0.5 * x)
+    X_valid = np.linspace(0.1, 0.9, 20).reshape(-1, 1)
+    y_valid = (X_valid.ravel() > 0.5).astype(int)
+
+    best_name, metrics, _ = compare_calibrators(
+        base_model,
+        X_valid,
+        y_valid,
+        metric="log_loss",
+        minimum_isotonic_samples=50,
+    )
+
+    assert best_name == "platt"
+    assert "platt" in metrics
+    assert "isotonic" not in metrics
+
+
+def test_calibration_selector_uses_best_calibrator_predictions():
+    base_model = DummyModel(lambda x: x)
+    X_valid, y_valid = _generate_nonlinear_dataset()
+
+    selector = CalibrationSelector(metric="brier", minimum_isotonic_samples=50)
+    selector.fit(base_model, X_valid, y_valid)
+
+    assert selector.selected_calibrator_name == "isotonic"
+    assert "platt" in selector.metrics_
+    assert "isotonic" in selector.metrics_
+
+    calibrated_probs = selector.predict_proba(X_valid)
+    assert np.allclose(calibrated_probs, selector.calibrator_.predict_proba(X_valid))


### PR DESCRIPTION
## Summary
- add an isotonic calibrator implementation and shared utilities for metric-based comparison
- implement a calibration selector that chooses between Platt and isotonic calibration with sample-size guards
- cover the selection workflow with unit tests, including nonlinear cases and small-sample skips

## Testing
- PYTHONPATH=src pytest tests/test_calibration_selection.py
- PYTHONPATH=src pytest tests/test_model_calibration.py

------
https://chatgpt.com/codex/tasks/task_e_68d08a04cd50832fa8a74ae5656a5e5b