### PR TITLE
AI-405: implement MLflow model promotion hooks

### DIFF
--- a/src/nfl_pred/registry/__init__.py
+++ b/src/nfl_pred/registry/__init__.py
@@ -1,0 +1,17 @@
+"""Registry utilities for managing MLflow promotions."""
+
+from .promote import (
+    PromotionCriteria,
+    PromotionDecision,
+    PromotionResult,
+    evaluate_promotion,
+    promote_run,
+)
+
+__all__ = [
+    "PromotionCriteria",
+    "PromotionDecision",
+    "PromotionResult",
+    "evaluate_promotion",
+    "promote_run",
+]

--- a/src/nfl_pred/registry/promote.py
+++ b/src/nfl_pred/registry/promote.py
@@ -1,0 +1,207 @@
+"""Utilities for promoting MLflow runs into the model registry."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.tracking import MlflowClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+_MISSING_MODEL_CODES = {RESOURCE_DOES_NOT_EXIST, "RESOURCE_DOES_NOT_EXIST"}
+
+
+@dataclass(frozen=True)
+class PromotionCriteria:
+    """Thresholds that a run must satisfy to be eligible for promotion."""
+
+    max_holdout_brier: float
+    max_holdout_log_loss: float
+    max_cv_mean_brier: float | None = None
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    """Decision describing whether a run should be promoted."""
+
+    promote: bool
+    rationale: str
+
+
+@dataclass(frozen=True)
+class PromotionResult:
+    """Result returned after evaluating and applying promotion logic."""
+
+    run_id: str
+    promoted: bool
+    rationale: str
+    decision_path: Path
+    model_name: str | None = None
+    model_version: int | None = None
+
+
+_REQUIRED_METRICS = ("holdout_brier", "holdout_log_loss")
+_OPTIONAL_METRICS = ("cv_mean_brier",)
+
+
+def evaluate_promotion(
+    metrics: Mapping[str, float],
+    criteria: PromotionCriteria,
+) -> PromotionDecision:
+    """Evaluate run metrics against promotion criteria."""
+
+    missing = [name for name in _REQUIRED_METRICS if name not in metrics]
+    if missing:
+        rationale = f"Missing required metrics: {', '.join(sorted(missing))}."
+        LOGGER.info("Promotion rejected: %s", rationale)
+        return PromotionDecision(promote=False, rationale=rationale)
+
+    holdout_brier = float(metrics["holdout_brier"])
+    if holdout_brier > criteria.max_holdout_brier:
+        rationale = (
+            f"Holdout Brier {holdout_brier:.4f} exceeds threshold {criteria.max_holdout_brier:.4f}."
+        )
+        LOGGER.info("Promotion rejected: %s", rationale)
+        return PromotionDecision(promote=False, rationale=rationale)
+
+    holdout_log_loss = float(metrics["holdout_log_loss"])
+    if holdout_log_loss > criteria.max_holdout_log_loss:
+        rationale = (
+            "Holdout log-loss {:.4f} exceeds threshold {:.4f}.".format(
+                holdout_log_loss,
+                criteria.max_holdout_log_loss,
+            )
+        )
+        LOGGER.info("Promotion rejected: %s", rationale)
+        return PromotionDecision(promote=False, rationale=rationale)
+
+    if criteria.max_cv_mean_brier is not None:
+        if "cv_mean_brier" not in metrics:
+            rationale = "Missing cv_mean_brier metric required by criteria."
+            LOGGER.info("Promotion rejected: %s", rationale)
+            return PromotionDecision(promote=False, rationale=rationale)
+
+        cv_mean_brier = float(metrics["cv_mean_brier"])
+        if cv_mean_brier > criteria.max_cv_mean_brier:
+            rationale = (
+                "Cross-validation mean Brier {:.4f} exceeds threshold {:.4f}.".format(
+                    cv_mean_brier,
+                    criteria.max_cv_mean_brier,
+                )
+            )
+            LOGGER.info("Promotion rejected: %s", rationale)
+            return PromotionDecision(promote=False, rationale=rationale)
+
+    return PromotionDecision(
+        promote=True,
+        rationale="All promotion criteria satisfied.",
+    )
+
+
+def promote_run(
+    run_id: str,
+    *,
+    tracking_uri: str | Path,
+    data_dir: str | Path,
+    model_name: str,
+    artifact_path: str,
+    criteria: PromotionCriteria,
+    stage: str = "Production",
+) -> PromotionResult:
+    """Evaluate a run and promote it in MLflow if criteria are met."""
+
+    mlflow.set_tracking_uri(str(tracking_uri))
+    mlflow.set_registry_uri(str(tracking_uri))
+    client = MlflowClient(tracking_uri=str(tracking_uri))
+
+    run = client.get_run(run_id)
+    metrics = run.data.metrics
+    decision = evaluate_promotion(metrics, criteria)
+
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    decisions_dir = Path(data_dir) / "models" / "promotion_decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    decision_path = decisions_dir / f"decision_{timestamp}_{run_id}.json"
+
+    payload = {
+        "run_id": run_id,
+        "decision_at": timestamp,
+        "promoted": decision.promote,
+        "rationale": decision.rationale,
+        "metrics": {name: metrics.get(name) for name in (*_REQUIRED_METRICS, *_OPTIONAL_METRICS)},
+        "criteria": {
+            "max_holdout_brier": criteria.max_holdout_brier,
+            "max_holdout_log_loss": criteria.max_holdout_log_loss,
+            "max_cv_mean_brier": criteria.max_cv_mean_brier,
+        },
+    }
+    decision_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    tag_payload = {
+        "promoted": "true" if decision.promote else "false",
+        "promotion_checked_at": timestamp,
+        "promotion_rationale": decision.rationale,
+    }
+
+    model_version: int | None = None
+
+    if decision.promote:
+        _ensure_registered_model(client, model_name)
+
+        source = f"runs:/{run_id}/{artifact_path}"
+        version = client.create_model_version(
+            name=model_name,
+            source=source,
+            run_id=run_id,
+        )
+        client.transition_model_version_stage(
+            name=model_name,
+            version=version.version,
+            stage=stage,
+            archive_existing_versions=True,
+        )
+
+        model_version = int(version.version)
+        tag_payload["model_id"] = f"{model_name}:{model_version}"
+        LOGGER.info(
+            "Promoted run %s to model '%s' version %s at stage %s.",
+            run_id,
+            model_name,
+            model_version,
+            stage,
+        )
+    else:
+        LOGGER.info("Promotion skipped for run %s: %s", run_id, decision.rationale)
+
+    for key, value in tag_payload.items():
+        client.set_tag(run_id, key, value)
+
+    return PromotionResult(
+        run_id=run_id,
+        promoted=decision.promote,
+        rationale=decision.rationale,
+        decision_path=decision_path,
+        model_name=model_name if decision.promote else None,
+        model_version=model_version,
+    )
+
+
+def _ensure_registered_model(client: MlflowClient, model_name: str) -> None:
+    """Create the registered model if it does not already exist."""
+
+    try:
+        client.get_registered_model(model_name)
+    except MlflowException as exc:  # pragma: no cover - defensive
+        if exc.error_code in _MISSING_MODEL_CODES:
+            client.create_registered_model(model_name)
+        else:
+            raise

--- a/tests/test_registry_promote.py
+++ b/tests/test_registry_promote.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import mlflow
+import pytest
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+
+from nfl_pred.registry.promote import (
+    PromotionCriteria,
+    PromotionDecision,
+    evaluate_promotion,
+    promote_run,
+)
+
+
+@pytest.fixture()
+def tracking_setup(tmp_path: Path) -> tuple[str, Path]:
+    tracking_uri = tmp_path / "mlruns"
+    data_dir = tmp_path / "artifacts"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return str(tracking_uri), data_dir
+
+
+def _create_run(
+    tracking_uri: str,
+    artifact_dir: Path,
+    *,
+    holdout_brier: float,
+    holdout_log_loss: float,
+    cv_mean_brier: float | None,
+    artifact_contents: str,
+) -> str:
+    mlflow.set_tracking_uri(tracking_uri)
+    with mlflow.start_run() as active_run:
+        mlflow.log_metric("holdout_brier", holdout_brier)
+        mlflow.log_metric("holdout_log_loss", holdout_log_loss)
+        if cv_mean_brier is not None:
+            mlflow.log_metric("cv_mean_brier", cv_mean_brier)
+
+        model_file = artifact_dir / "model.joblib"
+        model_file.write_text(artifact_contents, encoding="utf-8")
+        mlflow.log_artifact(str(model_file), artifact_path="models")
+        model_file.unlink()
+
+        run_id = active_run.info.run_id
+
+    return run_id
+
+
+def test_evaluate_promotion_success() -> None:
+    criteria = PromotionCriteria(max_holdout_brier=0.2, max_holdout_log_loss=0.69, max_cv_mean_brier=0.21)
+    decision = evaluate_promotion(
+        {"holdout_brier": 0.18, "holdout_log_loss": 0.65, "cv_mean_brier": 0.20},
+        criteria,
+    )
+
+    assert decision == PromotionDecision(promote=True, rationale="All promotion criteria satisfied.")
+
+
+def test_evaluate_promotion_missing_metric() -> None:
+    criteria = PromotionCriteria(max_holdout_brier=0.2, max_holdout_log_loss=0.69)
+    decision = evaluate_promotion({"holdout_brier": 0.18}, criteria)
+
+    assert not decision.promote
+    assert "Missing required metrics" in decision.rationale
+
+
+@pytest.mark.parametrize(
+    "holdout_brier, holdout_log_loss, expected", [(0.18, 0.65, True), (0.24, 0.65, False), (0.18, 0.72, False)],
+)
+def test_promote_run_applies_criteria(
+    tracking_setup: tuple[str, Path],
+    holdout_brier: float,
+    holdout_log_loss: float,
+    expected: bool,
+) -> None:
+    tracking_uri, data_dir = tracking_setup
+    criteria = PromotionCriteria(max_holdout_brier=0.2, max_holdout_log_loss=0.7)
+
+    run_id = _create_run(
+        tracking_uri,
+        data_dir,
+        holdout_brier=holdout_brier,
+        holdout_log_loss=holdout_log_loss,
+        cv_mean_brier=None,
+        artifact_contents="model-binary",
+    )
+
+    result = promote_run(
+        run_id,
+        tracking_uri=tracking_uri,
+        data_dir=data_dir,
+        model_name="baseline",
+        artifact_path="models/model.joblib",
+        criteria=criteria,
+        stage="Production",
+    )
+
+    client = MlflowClient(tracking_uri=tracking_uri)
+    run_tags = client.get_run(run_id).data.tags
+    decision_path = result.decision_path
+
+    assert decision_path.exists()
+    payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["run_id"] == run_id
+    assert payload["promoted"] == expected
+
+    if expected:
+        assert result.promoted
+        assert run_tags["promoted"] == "true"
+        assert "model_id" in run_tags
+        registered = client.get_registered_model("baseline")
+        assert registered.name == "baseline"
+        versions = client.get_latest_versions("baseline", stages=["Production"])
+        assert versions and versions[0].current_stage == "Production"
+    else:
+        assert not result.promoted
+        assert run_tags["promoted"] == "false"
+        assert "model_id" not in run_tags
+        with pytest.raises(MlflowException):
+            client.get_registered_model("baseline")
+
+


### PR DESCRIPTION
## Summary
- add a registry module that evaluates promotion criteria and registers eligible runs in MLflow
- persist promotion decisions and tag runs with promotion metadata for auditing
- add regression tests covering promotion success and rejection scenarios

## Testing
- PYTHONPATH=src pytest tests/test_registry_promote.py

------
https://chatgpt.com/codex/tasks/task_e_68d098b866f4832fa78a9bca09963d55