### PR TITLE
Add rule guard features for kickoff and overtime

### DIFF
--- a/src/nfl_pred/features/__init__.py
+++ b/src/nfl_pred/features/__init__.py
@@ -1,6 +1,7 @@
 """Feature engineering utilities for NFL prediction models."""
 
 from .injury_rollups import build_injury_rollups
+from .rules import append_rule_flags, compute_rule_flags
 from .stadium_join import join_stadium_metadata
 from .travel import compute_travel_features, haversine_miles
 from .weather import compute_weather_features
@@ -8,8 +9,10 @@ from .windows import RollingMetric, compute_group_rolling_windows
 
 __all__ = [
     "RollingMetric",
+    "append_rule_flags",
     "build_injury_rollups",
     "compute_group_rolling_windows",
+    "compute_rule_flags",
     "compute_travel_features",
     "compute_weather_features",
     "haversine_miles",

--- a/src/nfl_pred/features/build_features.py
+++ b/src/nfl_pred/features/build_features.py
@@ -37,6 +37,7 @@ import numpy as np
 import pandas as pd
 
 from nfl_pred.config import load_config
+from nfl_pred.features.rules import append_rule_flags
 from nfl_pred.features.schedule_meta import compute_schedule_meta
 from nfl_pred.features.team_week import compute_team_week_features
 from nfl_pred.features.travel import compute_travel_features
@@ -127,6 +128,7 @@ def build_and_store_features(
 
     team_week_features = compute_team_week_features(pbp, asof_ts=asof_ts)
     schedule_meta = compute_schedule_meta(schedule_filtered, asof_ts=asof_ts)
+    schedule_meta = append_rule_flags(schedule_meta)
     travel_features = compute_travel_features(
         schedule_filtered,
         team_locations=team_locations,

--- a/src/nfl_pred/features/rules.py
+++ b/src/nfl_pred/features/rules.py
@@ -1,0 +1,122 @@
+"""Rule-change guard features for the MVP feature matrix.
+
+This module centralises the logic that tags rows in the feature matrix when
+league rule changes take effect. The current scope covers two binary switches
+requested in the PRD:
+
+* ``kickoff_2024plus`` – flags seasons impacted by the 2024 kickoff overhaul.
+* ``ot_regular_2025plus`` – flags regular-season games from 2025 onward when
+  the updated overtime format is in place.
+
+The helpers operate on per-team schedule metadata (``season``, ``week``,
+``game_id``, ``team``) and avoid mutating the input frame. They intentionally
+use the season identifier as the primary activation key so postseason games
+played in the following calendar year continue to inherit the rule state of the
+season they belong to. Regular-season detection is handled via the numeric week
+value with the assumption that standard nflverse schedules encode Weeks 1–18 as
+the regular season. The behaviour is documented so future playoff-specific
+logic can refine the boundary when postseason handling lands in [AI-502].
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pandas as pd
+
+_MERGE_KEYS: Final[list[str]] = ["season", "week", "game_id", "team"]
+_KICKOFF_RULE_SEASON: Final[int] = 2024
+_OT_RULE_SEASON: Final[int] = 2025
+_REGULAR_SEASON_MAX_WEEK: Final[int] = 18
+
+
+def compute_rule_flags(
+    schedule_meta: pd.DataFrame,
+    *,
+    kickoff_cutover_season: int = _KICKOFF_RULE_SEASON,
+    ot_regular_cutover_season: int = _OT_RULE_SEASON,
+    regular_season_max_week: int = _REGULAR_SEASON_MAX_WEEK,
+) -> pd.DataFrame:
+    """Return per-team rule flag indicators for the supplied schedule frame.
+
+    Args:
+        schedule_meta: Per-team schedule metadata frame containing at least the
+            merge keys defined in :data:`_MERGE_KEYS`. The function does not
+            mutate the input and only inspects the key columns.
+        kickoff_cutover_season: Season (inclusive) when the reimagined kickoff
+            rules are considered active. Defaults to ``2024`` per PRD guidance.
+        ot_regular_cutover_season: Season (inclusive) when the updated
+            regular-season overtime procedure activates. Defaults to ``2025``.
+        regular_season_max_week: Highest week number treated as regular season
+            when deriving the overtime flag. Defaults to ``18`` which aligns
+            with the current NFL schedule format.
+
+    Returns:
+        ``DataFrame`` with the merge keys and two boolean columns named
+        ``kickoff_2024plus`` and ``ot_regular_2025plus``.
+
+    Boundary notes:
+        * ``kickoff_2024plus`` flips to ``True`` for every row whose season is
+          greater than or equal to the configured cutoff, including postseason
+          games assigned to that season.
+        * ``ot_regular_2025plus`` flips to ``True`` for rows at or beyond the
+          overtime cutoff season **and** whose numeric week is within the
+          regular-season range. Postseason rows therefore stay ``False`` until a
+          dedicated postseason flag is introduced in [AI-502].
+    """
+
+    missing = [column for column in _MERGE_KEYS if column not in schedule_meta.columns]
+    if missing:
+        raise KeyError(f"Schedule frame missing required columns for rule flags: {missing}")
+
+    working = schedule_meta[_MERGE_KEYS].copy()
+
+    season_numeric = pd.to_numeric(working["season"], errors="coerce")
+    week_numeric = pd.to_numeric(working["week"], errors="coerce")
+
+    kickoff_flag = season_numeric.ge(kickoff_cutover_season)
+    kickoff_flag = kickoff_flag.fillna(False)
+
+    ot_flag = season_numeric.ge(ot_regular_cutover_season)
+    regular_season_mask = week_numeric.le(regular_season_max_week)
+    ot_flag = ot_flag & regular_season_mask.fillna(False)
+
+    working["kickoff_2024plus"] = kickoff_flag.astype(bool)
+    working["ot_regular_2025plus"] = ot_flag.astype(bool)
+
+    return working
+
+
+def append_rule_flags(
+    features: pd.DataFrame,
+    *,
+    kickoff_cutover_season: int = _KICKOFF_RULE_SEASON,
+    ot_regular_cutover_season: int = _OT_RULE_SEASON,
+    regular_season_max_week: int = _REGULAR_SEASON_MAX_WEEK,
+) -> pd.DataFrame:
+    """Return a copy of ``features`` with rule flag columns appended.
+
+    The helper merges the output of :func:`compute_rule_flags` back into the
+    provided frame. Existing columns remain untouched and the shape of the
+    returned frame matches the input.
+    """
+
+    if features.empty:
+        empty = features.copy()
+        empty["kickoff_2024plus"] = pd.Series(dtype=bool)
+        empty["ot_regular_2025plus"] = pd.Series(dtype=bool)
+        return empty
+
+    rule_flags = compute_rule_flags(
+        features,
+        kickoff_cutover_season=kickoff_cutover_season,
+        ot_regular_cutover_season=ot_regular_cutover_season,
+        regular_season_max_week=regular_season_max_week,
+    )
+
+    merged = features.merge(rule_flags, on=_MERGE_KEYS, how="left", validate="one_to_one")
+    return merged
+
+
+__all__ = ["append_rule_flags", "compute_rule_flags"]
+

--- a/tests/test_rule_flags.py
+++ b/tests/test_rule_flags.py
@@ -1,0 +1,102 @@
+"""Unit tests for rule flag feature helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nfl_pred.features.build_features import _join_feature_components
+from nfl_pred.features.rules import append_rule_flags, compute_rule_flags
+
+
+def _schedule_meta_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "season": [2023, 2024, 2025, 2025],
+            "week": [18, 1, 1, 20],
+            "game_id": [
+                "2023_18_KC_LV",
+                "2024_01_NE_MIA",
+                "2025_01_NE_BUF",
+                "2025_20_NE_BUF",
+            ],
+            "team": ["KC", "NE", "NE", "NE"],
+            "opponent": ["LV", "MIA", "BUF", "BUF"],
+            "home_away": ["home", "home", "home", "home"],
+            "start_time": [
+                pd.Timestamp("2024-01-07 18:00:00+00:00"),
+                pd.Timestamp("2024-09-08 17:00:00+00:00"),
+                pd.Timestamp("2025-09-07 17:00:00+00:00"),
+                pd.Timestamp("2026-01-18 21:30:00+00:00"),
+            ],
+            "rest_days": [7.0, 7.0, 7.0, 7.0],
+            "short_week": [False, False, False, False],
+            "kickoff_bucket": ["late", "early", "early", "late"],
+        }
+    )
+
+
+def test_compute_rule_flags_activation_boundaries() -> None:
+    schedule_meta = _schedule_meta_frame()
+
+    flags = compute_rule_flags(schedule_meta)
+
+    kc_row = flags.loc[flags["game_id"] == "2023_18_KC_LV"].iloc[0]
+    assert bool(kc_row["kickoff_2024plus"]) is False
+    assert bool(kc_row["ot_regular_2025plus"]) is False
+
+    kickoff_row = flags.loc[flags["game_id"] == "2024_01_NE_MIA"].iloc[0]
+    assert bool(kickoff_row["kickoff_2024plus"]) is True
+    assert bool(kickoff_row["ot_regular_2025plus"]) is False
+
+    ot_row = flags.loc[flags["game_id"] == "2025_01_NE_BUF"].iloc[0]
+    assert bool(ot_row["kickoff_2024plus"]) is True
+    assert bool(ot_row["ot_regular_2025plus"]) is True
+
+    postseason_row = flags.loc[flags["game_id"] == "2025_20_NE_BUF"].iloc[0]
+    assert bool(postseason_row["kickoff_2024plus"]) is True
+    assert bool(postseason_row["ot_regular_2025plus"]) is False
+
+
+def test_append_rule_flags_preserves_shape_and_dtypes() -> None:
+    schedule_meta = _schedule_meta_frame()
+
+    augmented = append_rule_flags(schedule_meta)
+
+    assert augmented.shape[0] == schedule_meta.shape[0]
+    assert pd.api.types.is_bool_dtype(augmented["kickoff_2024plus"])
+    assert pd.api.types.is_bool_dtype(augmented["ot_regular_2025plus"])
+
+    with pytest.raises(KeyError):
+        compute_rule_flags(schedule_meta.drop(columns=["team"]))
+
+
+def test_rule_flags_flow_through_feature_join() -> None:
+    schedule_meta = append_rule_flags(_schedule_meta_frame())
+
+    travel = schedule_meta[["season", "week", "game_id", "team"]].copy()
+    travel["travel_miles"] = [0.0, 150.0, 200.0, 400.0]
+
+    team_week = pd.DataFrame(
+        {
+            "season": [2023, 2024, 2025],
+            "week": [18, 1, 1],
+            "team": ["KC", "NE", "NE"],
+            "plays_offense": [60, 58, 62],
+        }
+    )
+
+    weather = schedule_meta[["season", "week", "game_id", "team"]].copy()
+    weather["wx_temp"] = [35.0, 70.0, 68.0, 42.0]
+
+    assembled = _join_feature_components(
+        schedule_meta=schedule_meta,
+        travel_features=travel,
+        team_week_features=team_week,
+        weather_features=weather,
+    )
+
+    assert {"kickoff_2024plus", "ot_regular_2025plus"} <= set(assembled.columns)
+
+    ot_rows = assembled.loc[assembled["ot_regular_2025plus"]]
+    assert ot_rows["week"].tolist() == [1]


### PR DESCRIPTION
## Summary
- add rule flag helper module that computes kickoff_2024plus and ot_regular_2025plus with documented boundaries
- expose rule flag helpers through the features package and wire them into feature assembly
- cover rule guard behaviour with dedicated unit tests, including join propagation

## Testing
- PYTHONPATH=src pytest tests/test_rule_flags.py

------
https://chatgpt.com/codex/tasks/task_e_68d09ce57f88832fa69c982d8f74e658