### PR TITLE
[AI-502] Add playoff handling flags and training filters

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -13,3 +13,6 @@ monitoring:
     brier_deterioration_pct: 0.1
     psi_threshold: 0.2
     psi_feature_count: 5
+training:
+  playoffs:
+    mode: regular_only

--- a/src/nfl_pred/features/__init__.py
+++ b/src/nfl_pred/features/__init__.py
@@ -1,6 +1,7 @@
 """Feature engineering utilities for NFL prediction models."""
 
 from .injury_rollups import build_injury_rollups
+from .playoffs import append_playoff_flags, compute_playoff_flags
 from .rules import append_rule_flags, compute_rule_flags
 from .stadium_join import join_stadium_metadata
 from .travel import compute_travel_features, haversine_miles
@@ -9,8 +10,10 @@ from .windows import RollingMetric, compute_group_rolling_windows
 
 __all__ = [
     "RollingMetric",
+    "append_playoff_flags",
     "append_rule_flags",
     "build_injury_rollups",
+    "compute_playoff_flags",
     "compute_group_rolling_windows",
     "compute_rule_flags",
     "compute_travel_features",

--- a/src/nfl_pred/features/build_features.py
+++ b/src/nfl_pred/features/build_features.py
@@ -37,6 +37,7 @@ import numpy as np
 import pandas as pd
 
 from nfl_pred.config import load_config
+from nfl_pred.features.playoffs import append_playoff_flags
 from nfl_pred.features.rules import append_rule_flags
 from nfl_pred.features.schedule_meta import compute_schedule_meta
 from nfl_pred.features.team_week import compute_team_week_features
@@ -128,6 +129,7 @@ def build_and_store_features(
 
     team_week_features = compute_team_week_features(pbp, asof_ts=asof_ts)
     schedule_meta = compute_schedule_meta(schedule_filtered, asof_ts=asof_ts)
+    schedule_meta = append_playoff_flags(schedule_meta, schedule_filtered)
     schedule_meta = append_rule_flags(schedule_meta)
     travel_features = compute_travel_features(
         schedule_filtered,

--- a/src/nfl_pred/features/playoffs.py
+++ b/src/nfl_pred/features/playoffs.py
@@ -1,0 +1,172 @@
+"""Playoff handling utilities for feature assembly.
+
+This module exposes helpers that tag schedule-derived feature rows with
+postseason indicators. The functions operate on the raw schedule frame used by
+the MVP feature builder and return per-team rows that can be merged with other
+feature components. The implementation avoids mutating the input frames and
+defaults to the regular-season-only behaviour required by the MVP until a
+configuration toggle opts into postseason data.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Iterable
+
+import numpy as np
+import pandas as pd
+
+_MERGE_KEYS: Final[list[str]] = ["season", "week", "game_id", "team"]
+_REQUIRED_SCHEDULE_COLUMNS: Final[set[str]] = {
+    "season",
+    "week",
+    "game_id",
+    "home_team",
+    "away_team",
+}
+_DEFAULT_POSTSEASON_GAME_TYPES: Final[frozenset[str]] = frozenset({"POST", "SB"})
+
+
+def compute_playoff_flags(
+    schedule: pd.DataFrame,
+    *,
+    postseason_game_types: Iterable[str] = _DEFAULT_POSTSEASON_GAME_TYPES,
+    fallback_week_threshold: int | None = 18,
+) -> pd.DataFrame:
+    """Return per-team postseason flags for the provided schedule frame.
+
+    Args:
+        schedule: Raw schedule frame with at least the columns in
+            :data:`_REQUIRED_SCHEDULE_COLUMNS`.
+        postseason_game_types: Game type labels that should be treated as
+            postseason contests when the schedule includes a ``game_type``
+            column. Values are upper-cased before comparison. Defaults to the
+            nflverse ``POST`` convention and the Super Bowl ``SB`` label.
+        fallback_week_threshold: Numeric week strictly above which rows are
+            considered postseason when ``game_type`` is missing. ``None``
+            disables the fallback.
+
+    Returns:
+        ``DataFrame`` with columns ``season``, ``week``, ``game_id``, ``team``,
+        ``is_postseason`` (boolean), and ``season_phase`` (string).
+
+    Raises:
+        KeyError: When required schedule columns are missing.
+    """
+
+    missing = sorted(column for column in _REQUIRED_SCHEDULE_COLUMNS if column not in schedule.columns)
+    if missing:
+        raise KeyError(f"Schedule frame missing required columns for playoff flags: {missing}")
+
+    if schedule.empty:
+        return pd.DataFrame(columns=_MERGE_KEYS + ["is_postseason", "season_phase"])
+
+    working = schedule.copy()
+
+    season_numeric = pd.to_numeric(working["season"], errors="coerce")
+    week_numeric = pd.to_numeric(working["week"], errors="coerce")
+    valid_mask = season_numeric.notna() & week_numeric.notna()
+    if not valid_mask.all():
+        working = working.loc[valid_mask].copy()
+        season_numeric = season_numeric.loc[valid_mask]
+        week_numeric = week_numeric.loc[valid_mask]
+
+    working["season"] = season_numeric.astype(int)
+    working["week"] = week_numeric.astype(int)
+    working["game_id"] = working["game_id"].astype(str)
+
+    postseason_types = {str(value).strip().upper() for value in postseason_game_types}
+
+    if "game_type" in working.columns and postseason_types:
+        raw_types = working["game_type"]
+        game_type = raw_types.astype(str).str.upper().str.strip()
+        is_postseason = game_type.isin(postseason_types)
+    else:
+        is_postseason = pd.Series(False, index=working.index, dtype=bool)
+
+    if fallback_week_threshold is not None:
+        fallback_flag = week_numeric.gt(int(fallback_week_threshold)).fillna(False)
+        is_postseason = is_postseason.fillna(False) | fallback_flag
+
+    flags = is_postseason.fillna(False).astype(bool)
+    working["is_postseason"] = flags
+
+    base_columns = ["season", "week", "game_id", "is_postseason"]
+
+    home = working[base_columns + ["home_team"]].copy()
+    home.rename(columns={"home_team": "team"}, inplace=True)
+
+    away = working[base_columns + ["away_team"]].copy()
+    away.rename(columns={"away_team": "team"}, inplace=True)
+
+    combined = pd.concat([home, away], ignore_index=True, sort=False)
+    combined["team"] = combined["team"].astype(str)
+    combined["season_phase"] = np.where(combined["is_postseason"], "postseason", "regular")
+
+    combined = combined[_MERGE_KEYS + ["is_postseason", "season_phase"]]
+    combined = combined.sort_values(_MERGE_KEYS).reset_index(drop=True)
+    return combined
+
+
+def append_playoff_flags(
+    features: pd.DataFrame,
+    schedule: pd.DataFrame,
+    *,
+    postseason_game_types: Iterable[str] = _DEFAULT_POSTSEASON_GAME_TYPES,
+    fallback_week_threshold: int | None = 18,
+) -> pd.DataFrame:
+    """Return ``features`` with postseason indicators merged in.
+
+    Args:
+        features: Feature frame with at least the merge keys defined in
+            :data:`_MERGE_KEYS`.
+        schedule: Schedule frame used to derive postseason flags.
+        postseason_game_types: Passed through to
+            :func:`compute_playoff_flags`.
+        fallback_week_threshold: Passed through to
+            :func:`compute_playoff_flags`.
+
+    Returns:
+        Copy of ``features`` including ``is_postseason`` and ``season_phase``
+        columns.
+    """
+
+    missing = [column for column in _MERGE_KEYS if column not in features.columns]
+    if missing:
+        raise KeyError(f"Feature frame missing required columns for playoff merge: {missing}")
+
+    if features.empty:
+        empty = features.copy()
+        empty["is_postseason"] = pd.Series(dtype=bool)
+        empty["season_phase"] = pd.Series(dtype="string")
+        return empty
+
+    playoff_flags = compute_playoff_flags(
+        schedule,
+        postseason_game_types=postseason_game_types,
+        fallback_week_threshold=fallback_week_threshold,
+    )
+
+    if playoff_flags.empty:
+        merged = features.copy()
+        merged["is_postseason"] = False
+        merged["season_phase"] = "regular"
+        return merged
+
+    merged = features.merge(
+        playoff_flags,
+        on=_MERGE_KEYS,
+        how="left",
+        validate="one_to_one",
+    )
+
+    merged["is_postseason"] = merged["is_postseason"].fillna(False).astype(bool)
+    if "season_phase" in merged.columns:
+        merged["season_phase"] = merged["season_phase"].fillna("regular").astype(str)
+    else:
+        merged["season_phase"] = np.where(merged["is_postseason"], "postseason", "regular")
+
+    return merged
+
+
+__all__ = ["append_playoff_flags", "compute_playoff_flags"]
+

--- a/tests/test_playoff_handling.py
+++ b/tests/test_playoff_handling.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from nfl_pred.features.playoffs import append_playoff_flags, compute_playoff_flags
+from nfl_pred.pipeline.train import _apply_playoff_mode
+
+
+def test_compute_playoff_flags_marks_postseason_games() -> None:
+    schedule = pd.DataFrame(
+        {
+            "season": [2023, 2023],
+            "week": [18, 19],
+            "game_id": ["2023_18_BUF_MIA", "2023_19_KC_BAL"],
+            "game_type": ["REG", "POST"],
+            "home_team": ["BUF", "BAL"],
+            "away_team": ["MIA", "KC"],
+        }
+    )
+
+    flags = compute_playoff_flags(schedule)
+
+    expected = pd.DataFrame(
+        {
+            "season": [2023, 2023, 2023, 2023],
+            "week": [18, 18, 19, 19],
+            "game_id": [
+                "2023_18_BUF_MIA",
+                "2023_18_BUF_MIA",
+                "2023_19_KC_BAL",
+                "2023_19_KC_BAL",
+            ],
+            "team": ["BUF", "MIA", "BAL", "KC"],
+            "is_postseason": [False, False, True, True],
+            "season_phase": ["regular", "regular", "postseason", "postseason"],
+        }
+    )
+
+    pd.testing.assert_frame_equal(flags, expected)
+
+
+def test_compute_playoff_flags_fallback_without_game_type() -> None:
+    schedule = pd.DataFrame(
+        {
+            "season": [2024],
+            "week": [20],
+            "game_id": ["2024_20_SB"],
+            "home_team": ["AFC"],
+            "away_team": ["NFC"],
+        }
+    )
+
+    flags = compute_playoff_flags(schedule, postseason_game_types=())
+
+    assert flags.loc[:, "is_postseason"].tolist() == [True, True]
+    assert flags.loc[:, "season_phase"].tolist() == ["postseason", "postseason"]
+
+
+def test_append_playoff_flags_merges_indicators() -> None:
+    features = pd.DataFrame(
+        {
+            "season": [2023, 2023],
+            "week": [18, 19],
+            "game_id": ["2023_18_BUF_MIA", "2023_19_KC_BAL"],
+            "team": ["BUF", "BAL"],
+            "metric": [1.0, 2.0],
+        }
+    )
+
+    schedule = pd.DataFrame(
+        {
+            "season": [2023, 2023],
+            "week": [18, 19],
+            "game_id": ["2023_18_BUF_MIA", "2023_19_KC_BAL"],
+            "game_type": ["REG", "POST"],
+            "home_team": ["BUF", "BAL"],
+            "away_team": ["MIA", "KC"],
+        }
+    )
+
+    enriched = append_playoff_flags(features, schedule)
+
+    assert enriched["is_postseason"].tolist() == [False, True]
+    assert enriched["season_phase"].tolist() == ["regular", "postseason"]
+
+
+def test_apply_playoff_mode_filters_expected_rows() -> None:
+    frame = pd.DataFrame(
+        {
+            "value": [1, 2, 3],
+            "is_postseason": [True, False, True],
+        }
+    )
+
+    included = _apply_playoff_mode(frame, mode="include")
+    assert included.equals(frame)
+
+    regular_only = _apply_playoff_mode(frame, mode="regular_only")
+    assert regular_only["is_postseason"].tolist() == [False]
+
+    postseason_only = _apply_playoff_mode(frame, mode="postseason_only")
+    assert postseason_only["is_postseason"].tolist() == [True, True]
+
+    with pytest.raises(ValueError):
+        _apply_playoff_mode(frame, mode="unsupported")


### PR DESCRIPTION
## Summary
- add postseason flag utilities and wire them into feature assembly output
- expose configuration for playoff inclusion and filter training rows accordingly
- cover playoff handling and mode filtering with dedicated unit tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d09eec79c0832fa5971fd03d7db286