### PR TITLE
Fix CLI season parsing and DuckDB view registration

### DIFF
--- a/src/nfl_pred/storage/duckdb_client.py
+++ b/src/nfl_pred/storage/duckdb_client.py
@@ -107,9 +107,9 @@ class DuckDBClient(AbstractContextManager["DuckDBClient"]):
     def register_parquet(self, path: str, view: str) -> None:
         """Create or replace a view selecting from a Parquet file."""
         identifier = _escape_identifier(view)
+        escaped_path = path.replace("'", "''")
         self.connection.execute(
-            f"CREATE OR REPLACE VIEW {identifier} AS SELECT * FROM read_parquet(:path)",
-            {"path": path},
+            f"CREATE OR REPLACE VIEW {identifier} AS SELECT * FROM read_parquet('{escaped_path}')"
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import pytest
+import typer
+
+from nfl_pred import cli
+
+
+def test_merge_season_inputs_combines_option_and_args():
+    result = cli._merge_season_inputs([2022], [2023, 2024])
+    assert result == [2022, 2023, 2024]
+
+
+def test_merge_season_inputs_requires_value():
+    with pytest.raises(typer.BadParameter):
+        cli._merge_season_inputs(None, [])

--- a/tests/test_duckdb_client.py
+++ b/tests/test_duckdb_client.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pandas as pd
+
+from nfl_pred.storage.duckdb_client import DuckDBClient
+
+
+def test_register_parquet_handles_quoted_paths(tmp_path: Path) -> None:
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    parquet_path = tmp_path / "sam'ple.parquet"
+    df.to_parquet(parquet_path)
+
+    with DuckDBClient(":memory:") as client:
+        client.register_parquet(str(parquet_path), "sample_view")
+        result = client.read_sql("SELECT COUNT(*) AS cnt FROM sample_view")
+
+    assert result.loc[0, "cnt"] == len(df)


### PR DESCRIPTION
## Summary
- allow CLI ingestion and feature commands to accept multiple seasons regardless of flag usage
- escape parquet paths when registering DuckDB views to support older DuckDB builds
- add regression tests covering season input merging and DuckDB view registration

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0b9d12a98832fbd75c564ed8f48e8